### PR TITLE
Add monster domain events, reusable streaming hook, staged Sanctuary …

### DIFF
--- a/backend/core/events/__init__.py
+++ b/backend/core/events/__init__.py
@@ -42,9 +42,17 @@ from .workflow_events import (
   emit_workflow_queue_update
 )
 
+# Import monster domain event emission functions
+from .monster_events import (
+  emit_monster_created,
+  emit_monster_ability_added,
+  emit_monster_art_ready
+)
+
 # Import ai_events module to ensure events get registered
 from . import ai_events
 from . import workflow_events
+from . import monster_events
 
 __all__ = [
     # Event Bus
@@ -78,5 +86,10 @@ __all__ = [
     'emit_workflow_update',
     'emit_workflow_completed',
     'emit_workflow_failed',
-    'emit_workflow_queue_update'
+    'emit_workflow_queue_update',
+
+    # Monster Domain Event Emission Functions
+    'emit_monster_created',
+    'emit_monster_ability_added',
+    'emit_monster_art_ready'
 ]

--- a/backend/core/events/monster_events.py
+++ b/backend/core/events/monster_events.py
@@ -1,0 +1,61 @@
+# Monster Domain Events - Facts About Monsters in the Game World
+# Contains all monster lifecycle events and their emission helper functions
+# Emitted from the generator layer (game/monster/generator.py), so every
+# workflow that creates monsters/abilities/art broadcasts these automatically
+print(f"🔍 Loading {__file__.split('LlmMonsterHunter', 1)[-1]}")
+
+from typing import Dict, Any
+from .event_registry import register_events, _emit_from_schema
+
+# ===== MONSTER EVENT DEFINITIONS =====
+
+MONSTER_EVENTS = {
+
+    'monster.created': {
+        'data_fields': {
+            'monster': 'Complete monster data (from monster.to_dict())'
+        },
+        'send_to_frontend': True
+    },
+
+    'monster.ability_added': {
+        'data_fields': {
+            'monster_id': 'Database ID of the monster the ability belongs to',
+            'ability': 'Complete ability data (from ability.to_dict())'
+        },
+        'send_to_frontend': True
+    },
+
+    'monster.art_ready': {
+        'data_fields': {
+            'monster_id': 'Database ID of the monster the art belongs to',
+            'image_path': 'Relative path to the card art image'
+        },
+        'send_to_frontend': True
+    }
+}
+
+# Register monster events with the core registry
+register_events(MONSTER_EVENTS)
+
+# ===== MONSTER EVENT FUNCTIONS =====
+
+def emit_monster_created(monster: Dict[str, Any]) -> bool:
+    """Emit when a new monster is saved to the database"""
+    return _emit_from_schema('monster.created',
+        monster=monster
+    )
+
+def emit_monster_ability_added(monster_id: int, ability: Dict[str, Any]) -> bool:
+    """Emit when a new ability is saved for a monster"""
+    return _emit_from_schema('monster.ability_added',
+        monster_id=monster_id,
+        ability=ability
+    )
+
+def emit_monster_art_ready(monster_id: int, image_path: str) -> bool:
+    """Emit when card art is generated and attached to a monster"""
+    return _emit_from_schema('monster.art_ready',
+        monster_id=monster_id,
+        image_path=image_path
+    )

--- a/backend/game/monster/generator.py
+++ b/backend/game/monster/generator.py
@@ -6,6 +6,11 @@ from backend.models.monster import Monster
 from backend.models.ability import Ability
 from backend.game.utils import build_and_generate
 from backend.ai import gateway
+from backend.core.events import (
+    emit_monster_created,
+    emit_monster_ability_added,
+    emit_monster_art_ready
+)
 
 def generate_base_monster():
     """Generate monster - assumes valid inputs"""
@@ -20,7 +25,10 @@ def generate_base_monster():
 
     # Reload monster with abilities and card art
     monster = Monster.get_monster_by_id(monster.id)
-    
+
+    # A monster now exists in the game world
+    emit_monster_created(monster.to_dict())
+
     return monster
 
 def generate_card_art(monster: Monster):
@@ -35,9 +43,12 @@ def generate_card_art(monster: Monster):
     )
 
     image_path = image_result.get('image_path')
-    
+
     monster.set_card_art(image_path)
-    
+
+    # The monster's card art is now attached
+    emit_monster_art_ready(monster.id, image_path)
+
     return image_path
 
 def generate_ability(monster: Monster):
@@ -47,6 +58,9 @@ def generate_ability(monster: Monster):
 
     ability = Ability.create_from_llm_data(monster.id, parsed_data)
     ability.save()
+
+    # The monster has a new ability
+    emit_monster_ability_added(monster.id, ability.to_dict())
 
     return ability
 

--- a/frontend/src/api/events/monsterEventHandlers.js
+++ b/frontend/src/api/events/monsterEventHandlers.js
@@ -1,0 +1,36 @@
+// Monster Event Handlers - External (non-React) event handling
+// Transforms monster domain SSE events and broadcasts to event subscribers
+// These are facts about the game world (monster exists, has art, has ability),
+// not machinery progress - subscribe to react the moment they become true
+
+import { transformMonster, transformAbility } from "../transformers/monsters.js";
+import { broadcastEvent } from "../core/eventBroadcast.js";
+
+/**
+ * Monster Event Handlers - External event processing system
+ * Each handler transforms event data and broadcasts to subscribers
+ */
+export const monsterEventHandlers = {
+  'monster.created': (eventData) => {
+    const transformedData = {
+      monster: transformMonster(eventData.monster)
+    };
+    broadcastEvent('monsterCreated', transformedData);
+  },
+
+  'monster.ability_added': (eventData) => {
+    const transformedData = {
+      monsterId: eventData.monster_id || null,
+      ability: transformAbility(eventData.ability)
+    };
+    broadcastEvent('monsterAbilityAdded', transformedData);
+  },
+
+  'monster.art_ready': (eventData) => {
+    const transformedData = {
+      monsterId: eventData.monster_id || null,
+      imagePath: eventData.image_path || null
+    };
+    broadcastEvent('monsterArtReady', transformedData);
+  }
+};

--- a/frontend/src/api/events/useStreamedGeneration.js
+++ b/frontend/src/api/events/useStreamedGeneration.js
@@ -1,0 +1,47 @@
+// useStreamedGeneration - Reusable hook for streaming workflow-owned LLM text
+// The recurring pattern for vanity text throughout the game:
+//   1. A workflow emits step 'emit_generation_id' with the generation ID in its data
+//   2. We capture that ID and stream only the matching llmGenerationUpdate events
+// First used for dungeon entry text; encounter vanity text and riddles come next
+
+import { useRef } from 'react';
+import { useEventSubscription } from './useEventSubscription.js';
+
+/**
+ * Stream LLM text for a generation announced by a workflow
+ * @param {string} generationIdKey - Key inside the workflow step data that holds
+ *   the generation ID (e.g., 'entry_text_generation_id')
+ * @param {object} callbacks
+ * @param {function} callbacks.onText - Called with (partialText) on each streamed update
+ * @param {function} [callbacks.onComplete] - Called with (result) when the generation completes
+ */
+export const useStreamedGeneration = (generationIdKey, { onText, onComplete }) => {
+  // Ref (not state) - capturing the ID shouldn't cause a re-render
+  const generationIdRef = useRef(null);
+
+  // Capture the generation ID when the workflow announces it
+  useEventSubscription('workflowUpdate', (eventData) => {
+    if (eventData?.step === 'emit_generation_id') {
+      const generationId = eventData.data?.[generationIdKey];
+      if (generationId) {
+        generationIdRef.current = generationId;
+      }
+    }
+  });
+
+  // Stream text - only for our captured generation ID
+  useEventSubscription('llmGenerationUpdate', (eventData) => {
+    const generationId = generationIdRef.current;
+    if (generationId && eventData?.generationId === generationId) {
+      onText(eventData.partialText || '');
+    }
+  });
+
+  // Notify when our generation completes
+  useEventSubscription('llmGenerationCompleted', (eventData) => {
+    const generationId = generationIdRef.current;
+    if (onComplete && generationId && eventData?.generationId === generationId) {
+      onComplete(eventData.result);
+    }
+  });
+};

--- a/frontend/src/app/contexts/DungeonContext/hooks/useDungeonEvents.js
+++ b/frontend/src/app/contexts/DungeonContext/hooks/useDungeonEvents.js
@@ -1,14 +1,14 @@
 // useDungeonEvents.js - Minimal SSE event processing for dungeon workflow
 // Subscribes to specific broadcast events instead of context state,
 // so dungeon state only updates for events it actually cares about
-// Handles: generation ID capture, entry text streaming, door readiness
+// Handles: entry text streaming (via useStreamedGeneration) and door readiness
 
-import { useRef } from 'react';
 import { useEventSubscription } from '../../../../api/events/useEventSubscription.js';
+import { useStreamedGeneration } from '../../../../api/events/useStreamedGeneration.js';
 
 /**
  * Hook for processing minimal dungeon-related SSE events
- * Just handles generation ID and text streaming for now
+ * Just handles entry text streaming and doors for now
  * @param {object} stateHook - State hook from useDungeonState
  */
 export function useDungeonEvents(stateHook) {
@@ -22,25 +22,9 @@ export function useDungeonEvents(stateHook) {
     setDoors
   } = setters;
 
-  // Ref (not state) - capturing the ID shouldn't cause a re-render
-  const entryTextGenerationIdRef = useRef(null);
-
-  // Capture the entry text generation ID from workflow updates
-  useEventSubscription('workflowUpdate', (eventData) => {
-    if (eventData?.step === 'emit_generation_id') {
-      const generationId = eventData.data?.entry_text_generation_id;
-      if (generationId) {
-        entryTextGenerationIdRef.current = generationId;
-      }
-    }
-  });
-
-  // Stream entry text - only for our captured generation ID
-  useEventSubscription('llmGenerationUpdate', (eventData) => {
-    const entryTextGenerationId = entryTextGenerationIdRef.current;
-    if (entryTextGenerationId && eventData?.generationId === entryTextGenerationId) {
-      setEntryText(eventData.partialText || '');
-    }
+  // Stream the entry text announced by the enter_dungeon workflow
+  useStreamedGeneration('entry_text_generation_id', {
+    onText: (partialText) => setEntryText(partialText)
   });
 
   // Enable doors when the enter_dungeon workflow completes

--- a/frontend/src/app/contexts/EventContext/EventProvider.js
+++ b/frontend/src/app/contexts/EventContext/EventProvider.js
@@ -8,11 +8,13 @@ import { EventContext } from './EventContext.js';
 import { useSSE } from '../../../api/core/useSSE.js';
 import { aiEventHandlers } from '../../../api/events/aiEventHandlers.js';
 import { workflowEventHandlers } from '../../../api/events/workflowEventHandlers.js';
+import { monsterEventHandlers } from '../../../api/events/monsterEventHandlers.js';
 
 // Module-level constant - stable reference, combined once
 const sseEventHandlers = {
   ...aiEventHandlers,
-  ...workflowEventHandlers
+  ...workflowEventHandlers,
+  ...monsterEventHandlers
 };
 
 function EventProvider({ children }) {

--- a/frontend/src/screens/game/MonsterSanctuaryScreen.js
+++ b/frontend/src/screens/game/MonsterSanctuaryScreen.js
@@ -69,15 +69,18 @@ function MonsterSanctuaryScreen() {
     loadMonstersWithPagination();
   }, [loadMonstersWithPagination]);
 
-  // Auto-refresh when a new monster finishes generating - no manual refresh needed
-  useEventSubscription('workflowCompleted', (eventData) => {
-    if (eventData?.workflowItem?.workflowType === 'generate_detailed_monster') {
-      loadMonstersWithPagination();
-    }
+  // Staged auto-refresh from monster domain events - no manual refresh needed:
+  // card appears the moment the monster exists (before art), then updates
+  // as each ability lands, then again when card art is ready
+  useEventSubscription('monsterCreated', () => {
+    loadMonstersWithPagination();
   });
 
-  // Auto-refresh when card art finishes so the new image appears on the card
-  useEventSubscription('imageGenerationCompleted', () => {
+  useEventSubscription('monsterAbilityAdded', () => {
+    loadMonstersWithPagination();
+  });
+
+  useEventSubscription('monsterArtReady', () => {
     loadMonstersWithPagination();
   });
 


### PR DESCRIPTION
…refresh

Backend now states monster lifecycle facts explicitly instead of the frontend inferring them from workflow step names and generic generation events: monster.created, monster.ability_added, and monster.art_ready are emitted from the generator layer, so every current and future workflow that creates monsters (e.g. the upcoming dungeon encounter) broadcasts them automatically.

- backend/core/events/monster_events.py: event schemas + emit helpers
- game/monster/generator.py: emit after monster save, ability save, and card art attach
- frontend monsterEventHandlers.js: transform and broadcast as monsterCreated / monsterAbilityAdded / monsterArtReady
- useStreamedGeneration.js: extracted the capture-generation-id ->
  filter-llm-updates pattern from useDungeonEvents for reuse by encounter vanity text and riddles
- Monster Sanctuary staged refresh: card appears the moment the monster exists (before art), updates as abilities land, then again when card art is ready