### PR TITLE
Patch monster cards in place from domain events instead of refetching

### DIFF
--- a/frontend/src/app/hooks/useMonsters.js
+++ b/frontend/src/app/hooks/useMonsters.js
@@ -3,8 +3,9 @@
 // Super clean usage - just pass the function, defaults are automatic!
 // App hooks focus purely on business logic, services handle everything else
 
-import { useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useAsyncState } from '../../shared/hooks/useAsyncState.js';
+import { useEventSubscription } from '../../api/events/useEventSubscription.js';
 import * as monstersApi from '../../api/services/monster.js'
 
 // ===== MONSTER COLLECTION HOOKS =====
@@ -36,6 +37,52 @@ export function useMonsterCollection() {
     // Actions
     loadMonsters: api.execute,
     reset: api.reset
+  };
+}
+
+/**
+ * Hook for a monster collection that stays live via monster domain events
+ * Patches single monsters in place from event payloads (no refetch),
+ * so cards update without unmounting or losing their flip state
+ */
+export function useLiveMonsterCollection() {
+  const collection = useMonsterCollection();
+
+  // Local copy of the collection that we can patch per-monster
+  const [monsters, setMonsters] = useState(collection.monsters);
+
+  // Sync from API whenever a real load completes (initial load, pagination, filters)
+  useEffect(() => {
+    setMonsters(collection.monsters);
+  }, [collection.monsters]);
+
+  // Helper - update one monster in place, leave the rest untouched
+  const patchMonster = (monsterId, patch) => {
+    setMonsters(prev => prev.map(monster =>
+      monster.id === monsterId ? { ...monster, ...patch(monster) } : monster
+    ));
+  };
+
+  // Card art finished - attach it to just that monster's card
+  useEventSubscription('monsterArtReady', ({ monsterId, imagePath }) => {
+    if (!monsterId || !imagePath) return;
+    patchMonster(monsterId, () => ({
+      cardArt: { exists: true, relativePath: imagePath }
+    }));
+  });
+
+  // New ability landed - append it to just that monster's card
+  useEventSubscription('monsterAbilityAdded', ({ monsterId, ability }) => {
+    if (!monsterId || !ability) return;
+    patchMonster(monsterId, (monster) => ({
+      abilities: [...(monster.abilities || []), ability],
+      abilityCount: (monster.abilityCount || 0) + 1
+    }));
+  });
+
+  return {
+    ...collection,
+    monsters
   };
 }
 

--- a/frontend/src/components/cards/useMonsterCardViewer.js
+++ b/frontend/src/components/cards/useMonsterCardViewer.js
@@ -2,14 +2,14 @@
 // Encapsulates all viewer state management and provides pre-configured components
 // Reduces boilerplate from 4 things to just 2!
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import MonsterCard from './MonsterCard.js';
 import MonsterCardViewer from './MonsterCardViewer.js';
 
 /**
  * Custom hook for MonsterCard with built-in viewer functionality
  * Manages viewer state and provides pre-configured components
- * 
+ *
  * @returns {object} Hook result with MonsterCard component and viewer
  */
 export function useMonsterCardViewer() {
@@ -20,12 +20,16 @@ export function useMonsterCardViewer() {
   const closeViewer = () => setViewingMonster(null);
 
   // Pre-configured MonsterCard component that handles expand automatically
-  const MonsterCardWithViewer = (props) => (
-    <MonsterCard
-      {...props}
-      onExpandCard={setViewingMonster} // Automatically wired up!
-    />
-  );
+  // Memoized so it keeps the same component identity across re-renders -
+  // otherwise React remounts every card (losing flip state) each render
+  const MonsterCardWithViewer = useMemo(() => {
+    return (props) => (
+      <MonsterCard
+        {...props}
+        onExpandCard={setViewingMonster} // Automatically wired up!
+      />
+    );
+  }, []);
 
   // Pre-rendered viewer (conditionally shown)
   const viewer = viewingMonster ? (

--- a/frontend/src/screens/game/MonsterSanctuaryScreen.js
+++ b/frontend/src/screens/game/MonsterSanctuaryScreen.js
@@ -4,7 +4,7 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { usePagination } from "../../shared/ui/Pagination/usePagination.js";
-import { useMonsterCollection, useMonsterGeneration } from "../../app/hooks/useMonsters.js";
+import { useLiveMonsterCollection, useMonsterGeneration } from "../../app/hooks/useMonsters.js";
 import { useEventSubscription } from "../../api/events/useEventSubscription.js";
 import FullPagination, { PAGINATION_LAYOUTS } from "../../shared/ui/Pagination/PaginationPresets.js";
 import { 
@@ -32,7 +32,8 @@ function MonsterSanctuaryScreen() {
 
   const { MonsterCard, viewer } = useMonsterCardViewer();
 
-  // Domain hook - provides clean monster data
+  // Domain hook - clean monster data that stays live via monster domain events
+  // (art and abilities patch individual cards in place, no refetch)
   const {
     monsters,
     total,
@@ -40,7 +41,7 @@ function MonsterSanctuaryScreen() {
     isError,
     error,
     loadMonsters
-  } = useMonsterCollection();
+  } = useLiveMonsterCollection();
 
   // Monster generation hook
   const {
@@ -69,18 +70,9 @@ function MonsterSanctuaryScreen() {
     loadMonstersWithPagination();
   }, [loadMonstersWithPagination]);
 
-  // Staged auto-refresh from monster domain events - no manual refresh needed:
-  // card appears the moment the monster exists (before art), then updates
-  // as each ability lands, then again when card art is ready
+  // A brand-new monster changes the list itself, so refetch for that one;
+  // ability/art updates are patched in place by useLiveMonsterCollection
   useEventSubscription('monsterCreated', () => {
-    loadMonstersWithPagination();
-  });
-
-  useEventSubscription('monsterAbilityAdded', () => {
-    loadMonstersWithPagination();
-  });
-
-  useEventSubscription('monsterArtReady', () => {
     loadMonstersWithPagination();
   });
 
@@ -223,7 +215,9 @@ function MonsterSanctuaryScreen() {
         <Alert type="error" title="Loading Error" style={{ marginBottom: '20px' }}>
           {error?.message || 'Failed to load monsters'}
         </Alert>
-      ) : isLoading ? (
+      ) : isLoading && monsters.length === 0 ? (
+        // Spinner only when there is nothing to show yet - background refetches
+        // keep the grid mounted so cards keep their flip state
         <div style={{ textAlign: 'center', padding: '40px' }}>
           <LoadingSpinner size="section" type="cardFlip"/>
         </div>


### PR DESCRIPTION
Ability and art updates now modify only the affected monster card, using data carried by the monster.ability_added / monster.art_ready events - no API refetch at all. Cards keep whichever face they are showing: generating an ability while viewing the details face appends the new ability there without flipping the card, and finished card art attaches without disturbing a flipped card.

- useLiveMonsterCollection (app/hooks/useMonsters.js): wraps useMonsterCollection with per-monster event patching
- MonsterSanctuaryScreen: only monster.created triggers a list refetch; loading spinner only shows when the grid is empty, so background refetches no longer unmount cards (which reset their flip state)
- useMonsterCardViewer: memoize the wrapped MonsterCard so it keeps a stable component identity across re-renders - previously every Sanctuary re-render remounted all cards, losing flip state