### PR TITLE
Pre-generate path destinations, batch path generation, monster dialogue

### DIFF
--- a/backend/ai/llm/prompts/dungeon_generation.json
+++ b/backend/ai/llm/prompts/dungeon_generation.json
@@ -58,17 +58,17 @@
     "prompt_template": "You and your adventuring party ({party_summary}) are successfully exiting a dungeon adventure and returning to safety. Write 1-2 sentences describing your emergence from the depths and return to the outside world. Make it satisfying and conclusive, celebrating the completion of your underground exploration.\n\nResponse:"
   },
 
-  "path_choice": {
-    "description": "Generate one path leading onward from the current location - a route, not a destination",
-    "max_tokens": 400,
+  "path_choices": {
+    "description": "Generate a batch of distinct paths leading onward from the current location - routes, not destinations",
+    "max_tokens": 800,
     "temperature": 0.9,
     "parser": {
       "type": "json",
       "parser_name": "basic_parser",
-      "expected_fields": ["name", "description"],
-      "required_fields": ["name", "description"]
+      "expected_fields": ["paths"],
+      "required_fields": ["paths"]
     },
-    "prompt_template": "The adventuring party is currently at this location:\n\nLocation: {location_name}\nDescription: {location_description}\n\nGenerate ONE path leading onward from this location. A path is a physical route the party can take - a door, stairway, tunnel, opening, ladder, bridge, gap in a wall, etc. Describe the PATH ITSELF, not where it leads. The party should usually NOT be able to tell what lies beyond. Examples of good paths: a rusty trap door that may have been used by prison staff long ago, a spiral staircase leading upward, a hole through the brick wall that looks like it was made by a wrecking ball, a mysterious decorated wooden door that looks out of place.\n\nThese paths already exist here, so make this one different: {existing_paths}\n\nRespond with valid JSON in this exact format:\n{{\"name\": \"Short Path Name\", \"description\": \"1-2 sentence description of the path itself - what it looks like and hints of its history, NOT what lies beyond it.\"}}\n\nJSON:"
+    "prompt_template": "The adventuring party is currently at this location:\n\nLocation: {location_name}\nDescription: {location_description}\n\nGenerate {total_count} DIFFERENT paths leading onward from this location. A path is a physical route the party can take - a door, stairway, tunnel, opening, ladder, bridge, gap in a wall, etc. Describe each PATH ITSELF, not where it leads. The party should usually NOT be able to tell what lies beyond. Examples of good paths: a rusty trap door that may have been used by prison staff long ago, a spiral staircase leading upward, a hole through the brick wall that looks like it was made by a wrecking ball, a mysterious decorated wooden door that looks out of place.\n\nMake every path different from the others in kind and character - different structures, materials, directions, and moods.\n\nRespond with valid JSON in this exact format:\n{{\"paths\": [{{\"name\": \"Short Path Name\", \"description\": \"1-2 sentence description of the path itself - what it looks like and hints of its history, NOT what lies beyond it.\"}}, ...]}}\n\nThe paths array must contain exactly {total_count} entries. JSON:"
   },
 
   "exit_path": {

--- a/backend/ai/llm/prompts/encounter_generation.json
+++ b/backend/ai/llm/prompts/encounter_generation.json
@@ -24,28 +24,28 @@
   },
 
   "riddle": {
-    "description": "Generate a riddle (with its answer) that a monster asks the party",
-    "max_tokens": 400,
+    "description": "The monster greets the arriving party in character and challenges them with a riddle",
+    "max_tokens": 700,
     "temperature": 0.9,
     "parser": {
       "type": "json",
       "parser_name": "basic_parser",
-      "expected_fields": ["riddle", "answer"],
-      "required_fields": ["riddle", "answer"]
+      "expected_fields": ["greeting", "riddle", "answer"],
+      "required_fields": ["greeting", "riddle", "answer"]
     },
-    "prompt_template": "A monster is challenging an adventuring party with a riddle.\n\nThe monster:\nName: {monster_name}\nSpecies: {monster_species}\nDescription: {monster_description}\n\nGenerate a riddle this monster asks, spoken in the monster's voice and personality. The riddle should be clever but solvable - a classic-style riddle with a single clear answer (an object, creature, or concept). The answer should be a single word or short phrase.\n\nRespond with valid JSON in this exact format:\n{{\"riddle\": \"The riddle text, spoken in the monster's voice.\", \"answer\": \"the answer\"}}\n\nJSON:"
+    "prompt_template": "A monster dwells in this location:\n\nLocation: {location_name}\nDescription: {location_description}\n\nThe monster:\nName: {monster_name}\nSpecies: {monster_species}\nDescription: {monster_description}\n\nAn adventuring party has just walked into the monster's location. The party:\n{party_details}\n\nWrite the monster's spoken words to the party, in the monster's own voice and personality:\n\n1. greeting: The monster reacts to the party's arrival and gives ITS OWN reason for challenging them with a riddle. The reason should fit this monster and this place - maybe it guards this location and only lets the clever pass, maybe it is lonely and trades passage for entertainment, maybe it tests all who enter, maybe it is hungry but honorable. The greeting may address specific party members it finds interesting. End the greeting by announcing the challenge.\n\n2. riddle: The riddle itself, spoken by the monster. Clever but solvable - a classic-style riddle with a single clear answer (an object, creature, or concept). The answer should be a single word or short phrase.\n\nRespond with valid JSON in this exact format:\n{{\"greeting\": \"The monster's spoken greeting and justification, 2-4 sentences.\", \"riddle\": \"The riddle itself, spoken in the monster's voice.\", \"answer\": \"the answer\"}}\n\nJSON:"
   },
 
   "riddle_judgement": {
-    "description": "Judge whether the player's answer to a riddle is correct",
-    "max_tokens": 400,
-    "temperature": 0.3,
+    "description": "Judge the player's riddle answer strictly, then respond as the monster speaking to the party",
+    "max_tokens": 600,
+    "temperature": 0.4,
     "parser": {
       "type": "json",
       "parser_name": "basic_parser",
-      "expected_fields": ["correct", "verdict"],
-      "required_fields": ["correct", "verdict"]
+      "expected_fields": ["correct", "response"],
+      "required_fields": ["correct", "response"]
     },
-    "prompt_template": "You are a STRICT judge of a riddle contest. A monster asked this riddle:\n\nRiddle: {riddle}\n\nThe intended answer is: {correct_answer}\n\nThe player answered: {player_answer}\n\nThe ONLY question that matters: does the player's answer refer to the SAME THING as the intended answer \"{correct_answer}\"?\n\n- SAME thing (any spelling, capitalization, articles like a/an/the, plural, or a true synonym): correct = true\n- DIFFERENT thing: correct = false. It does NOT matter if the riddle could loosely or creatively apply to the player's answer - if it is not the same thing as \"{correct_answer}\", it is wrong. Do not be generous. Do not rationalize a different answer into being correct.\n\nRespond with valid JSON in this exact format:\n{{\"correct\": false, \"verdict\": \"One short in-character sentence from the monster reacting to the answer - gracious in defeat if the player was correct, gleeful if the player was wrong.\"}}\n\nUse true or false (lowercase, no quotes) for correct. JSON:"
+    "prompt_template": "You are a STRICT judge of a riddle contest, and you also speak for the monster who asked it.\n\nThe monster:\nName: {monster_name}\nSpecies: {monster_species}\nDescription: {monster_description}\n\nThe adventuring party being challenged:\n{party_details}\n\nThe monster asked this riddle: {riddle}\n\nThe intended answer is: {correct_answer}\n\nThe party answered: {player_answer}\n\nSTEP 1 - JUDGE. The ONLY question that matters: does the party's answer refer to the SAME THING as the intended answer \"{correct_answer}\"?\n- SAME thing (any spelling, capitalization, articles like a/an/the, plural, or a true synonym): correct = true\n- DIFFERENT thing: correct = false. It does NOT matter if the riddle could loosely or creatively apply to their answer - if it is not the same thing as \"{correct_answer}\", it is wrong. Do not be generous. Do not rationalize a different answer into being correct.\n\nSTEP 2 - RESPOND. Write the monster's spoken response to the party, in its own voice and personality, reacting to their answer. If they were correct: the monster keeps its word - impressed, gracious, or grudging as fits its character. If they were wrong: the monster relishes it or scolds them as fits its character. The response may address specific party members.\n\nRespond with valid JSON in this exact format:\n{{\"correct\": false, \"response\": \"The monster's spoken response to the party, 2-4 sentences in its own voice.\"}}\n\nUse true or false (lowercase, no quotes) for correct. JSON:"
   }
 }

--- a/backend/game/dungeon/events.py
+++ b/backend/game/dungeon/events.py
@@ -17,6 +17,11 @@ PATH_COUNT_RANGE = (2, 4)
 # Chance that one of the junction's paths is a dungeon exit
 EXIT_PATH_CHANCE = 0.33
 
+# How many paths the LLM generates per batch - more than we need, and we
+# use the LAST ones. Small local LLMs repeat themselves early; asking for
+# extra and taking the later entries plays to their strengths
+PATH_OVERGENERATE_COUNT = 6
+
 def assign_random_event() -> str:
     """Pick a random event for a path from the available events"""
     return random.choice(AVAILABLE_EVENTS)

--- a/backend/game/dungeon/generator.py
+++ b/backend/game/dungeon/generator.py
@@ -6,7 +6,12 @@ from typing import Dict, Any
 import random
 from backend.game.utils import build_and_generate, build_and_stream
 from backend.game.state.manager import get_party_summary
-from backend.game.dungeon.events import assign_random_event, roll_path_count, roll_include_exit
+from backend.game.dungeon.events import (
+    assign_random_event,
+    roll_path_count,
+    roll_include_exit,
+    PATH_OVERGENERATE_COUNT
+)
     
 def generate_entry_text(workflow_name) -> Dict[str, Any]:
     """Generate entry text - assumes valid party_summary"""
@@ -46,12 +51,13 @@ def generate_exit_text(party_summary: str, workflow_name) -> Dict[str, Any]:
 def generate_paths(location: Dict[str, Any], workflow_name: str) -> Dict[str, Dict[str, Any]]:
     """
     Generate the paths leading onward from a location
-    Rolls path count and exit inclusion, generates each path via LLM,
-    and assigns a hidden random event to every non-exit path
+    One batch LLM call over-generates paths (later entries are more
+    creative) and we keep the LAST ones. Every non-exit path gets a
+    hidden random event AND a pre-generated destination location, so
+    arrival displays instantly when the player chooses it
     """
 
     paths = {}
-    path_names = []
 
     count = roll_path_count()
     include_exit = roll_include_exit()
@@ -59,25 +65,39 @@ def generate_paths(location: Dict[str, Any], workflow_name: str) -> Dict[str, Di
     # An exit takes one of the rolled slots
     regular_count = count - 1 if include_exit else count
 
-    for i in range(regular_count):
-        variables = {
+    # One batch call for all paths - over-generated for variety
+    generated = []
+    try:
+        batch = build_and_generate('path_choices', workflow_name, {
             'location_name': location.get('name', 'Unknown Location'),
             'location_description': location.get('description', ''),
-            'existing_paths': ', '.join(path_names) if path_names else 'None yet'
-        }
+            'total_count': PATH_OVERGENERATE_COUNT
+        })
+        raw_paths = batch.get('paths') or []
+        generated = [
+            p for p in raw_paths
+            if isinstance(p, dict) and p.get('name') and p.get('description')
+        ]
+    except Exception:
+        generated = []
 
-        try:
-            path = build_and_generate('path_choice', workflow_name, variables)
-        except Exception:
-            path = _get_fallback_path()
+    # Small LLMs repeat themselves early - the later entries are the
+    # creative ones, so take from the END of the batch
+    chosen = generated[-regular_count:] if len(generated) >= regular_count else list(generated)
+    while len(chosen) < regular_count:
+        chosen.append(_get_fallback_path())
+
+    for i, path in enumerate(chosen):
+        # Pre-generate where this path leads (hidden from the player)
+        destination = generate_arrival_location(location, path, workflow_name)
 
         paths[f'path_{i + 1}'] = {
             'name': path.get('name', 'Mysterious Passage'),
             'description': path.get('description', ''),
             'type': 'path',
-            'event': assign_random_event()
+            'event': assign_random_event(),
+            'destination': destination
         }
-        path_names.append(path.get('name', 'Mysterious Passage'))
 
     if include_exit:
         variables = {

--- a/backend/game/dungeon/manager.py
+++ b/backend/game/dungeon/manager.py
@@ -64,15 +64,18 @@ def set_available_paths(paths: Dict[str, Any]) -> None:
     state['available_paths'] = paths
     save_dungeon_state(state)
 
+# Fields the player must never see - what waits behind each path
+_HIDDEN_PATH_FIELDS = ('event', 'destination')
+
 def get_public_paths() -> Dict[str, Any]:
     """
     Get available paths SAFE to send to the frontend
-    Strips the hidden 'event' field - the player must not know
-    what waits behind each path
+    Strips the hidden 'event' and 'destination' fields - the player
+    must not know what waits behind each path
     """
     paths = get_dungeon_state().get('available_paths', {})
     return {
-        path_id: {key: value for key, value in path.items() if key != 'event'}
+        path_id: {key: value for key, value in path.items() if key not in _HIDDEN_PATH_FIELDS}
         for path_id, path in paths.items()
     }
 

--- a/backend/game/dungeon/registered_workflows.py
+++ b/backend/game/dungeon/registered_workflows.py
@@ -87,7 +87,7 @@ def choose_path(context: dict, on_update: Callable[[str, Dict[str, Any]], None])
         )
         from backend.game.dungeon import manager
         from backend.game.monster.generator import generate_contextual_monster, generate_ability, generate_card_art
-        from backend.game.state.manager import get_party_summary
+        from backend.game.state.manager import get_party_summary, get_party_details
         from backend.game.utils import build_and_generate
 
         # Step 0 - validate required keys
@@ -118,10 +118,11 @@ def choose_path(context: dict, on_update: Callable[[str, Dict[str, Any]], None])
             })
 
         # === PATH BRANCH ===
-        # Step 1 - where does this path lead?
-        step = "generate_arrival_location"
+        # Step 1 - the destination was pre-generated with the path, so
+        # arrival is instant (fall back to generating for old saved paths)
+        step = "resolve_arrival_location"
         on_update(step, progress_data)
-        location = generate_arrival_location(previous_location, path, workflow_name)
+        location = path.get('destination') or generate_arrival_location(previous_location, path, workflow_name)
         manager.set_current_location(location)
 
         # Step 2 - announce the arrival location to the frontend
@@ -163,13 +164,17 @@ def choose_path(context: dict, on_update: Callable[[str, Dict[str, Any]], None])
             on_update(step, progress_data)
             generate_card_art(monster)
 
-            # Step 9 - the riddle (answer NEVER leaves the backend)
+            # Step 9 - the monster speaks: greeting with its own reason for
+            # the challenge, then the riddle (answer NEVER leaves the backend)
             step = "generate_riddle"
             on_update(step, progress_data)
             riddle_data = build_and_generate('riddle', workflow_name, {
+                'location_name': location.get('name', 'Unknown Location'),
+                'location_description': location.get('description', ''),
                 'monster_name': monster.name,
                 'monster_species': monster.species,
-                'monster_description': monster.description
+                'monster_description': monster.description,
+                'party_details': get_party_details()
             })
 
             manager.set_active_encounter({
@@ -183,6 +188,7 @@ def choose_path(context: dict, on_update: Callable[[str, Dict[str, Any]], None])
                 "event": "monster_riddle",
                 "current_location": location,
                 "monster_id": monster.id,
+                "greeting": riddle_data['greeting'],
                 "riddle": riddle_data['riddle']
             })
 
@@ -210,7 +216,9 @@ def answer_riddle(context: dict, on_update: Callable[[str, Dict[str, Any]], None
 
     try:
         from backend.game.dungeon import manager
+        from backend.game.state.manager import get_party_details
         from backend.game.utils import build_and_generate
+        from backend.models.monster import Monster
 
         # Step 0 - validate required keys
         step = "validate_context"
@@ -221,13 +229,20 @@ def answer_riddle(context: dict, on_update: Callable[[str, Dict[str, Any]], None
         if not encounter:
             raise Exception("No active encounter to answer")
 
-        # Step 1 - LLM judges the answer (leniently, semantically)
+        # The monster who asked - it responds to the party in character
+        monster = Monster.get_monster_by_id(encounter.get('monster_id'))
+
+        # Step 1 - LLM judges the answer strictly, then speaks as the monster
         step = "judge_answer"
         on_update(step, progress_data)
         judgement = build_and_generate('riddle_judgement', workflow_name, {
             'riddle': encounter['riddle'],
             'correct_answer': encounter['answer'],
-            'player_answer': context['player_answer']
+            'player_answer': context['player_answer'],
+            'monster_name': monster.name if monster else 'The monster',
+            'monster_species': monster.species if monster else 'Unknown',
+            'monster_description': monster.description if monster else '',
+            'party_details': get_party_details()
         })
 
         # Step 2 - the encounter is resolved either way
@@ -237,7 +252,7 @@ def answer_riddle(context: dict, on_update: Callable[[str, Dict[str, Any]], None
 
         return success_response({
             "correct": bool(judgement.get('correct')),
-            "verdict": judgement.get('verdict', '')
+            "response": judgement.get('response', '')
         })
 
     except Exception as e:

--- a/backend/game/state/manager.py
+++ b/backend/game/state/manager.py
@@ -72,6 +72,26 @@ def get_party_summary() -> str:
         return f"{', '.join(party_names[:-1])}, and {party_names[-1]}"
 
 
+def get_party_details() -> str:
+    """
+    Get a detailed text description of the active party for LLM context
+    One line per monster: name, species, and description
+    """
+
+    party_ids = ActiveParty.get_party_monster_ids()
+
+    if not party_ids:
+        return "A lone, empty-handed adventurer"
+
+    lines = []
+    for monster_id in party_ids:
+        monster = Monster.get_monster_by_id(monster_id)
+        if monster:
+            lines.append(f"- {monster.name} ({monster.species}): {monster.description}")
+
+    return "\n".join(lines) if lines else "A lone, empty-handed adventurer"
+
+
 def reset_game_state() -> Dict[str, Any]:
     """Reset all game state to initial values (for testing)"""
 

--- a/frontend/src/app/contexts/DungeonContext/hooks/useDungeonEvents.js
+++ b/frontend/src/app/contexts/DungeonContext/hooks/useDungeonEvents.js
@@ -24,6 +24,7 @@ export function useDungeonEvents(stateHook) {
     setArePathsReady,
     setEncounterText,
     setEncounterMonster,
+    setRiddleGreeting,
     setRiddle,
     setIsJudgingAnswer,
     setRiddleResult,
@@ -115,6 +116,7 @@ export function useDungeonEvents(stateHook) {
         if (result.exited) {
           setExitText(result.exit_text || 'You emerge back into the daylight.');
         } else if (result.event === 'monster_riddle') {
+          setRiddleGreeting(result.greeting || null);
           setRiddle(result.riddle || null);
         }
         break;
@@ -123,7 +125,7 @@ export function useDungeonEvents(stateHook) {
         setIsJudgingAnswer(false);
         setRiddleResult({
           correct: !!result.correct,
-          verdict: result.verdict || ''
+          response: result.response || ''
         });
         break;
 

--- a/frontend/src/app/contexts/DungeonContext/hooks/useDungeonState.js
+++ b/frontend/src/app/contexts/DungeonContext/hooks/useDungeonState.js
@@ -29,9 +29,10 @@ export function useDungeonState() {
   // Encounter state - streamed vanity text, the monster, and the riddle
   const [encounterText, setEncounterText] = useState('');
   const [encounterMonster, setEncounterMonster] = useState(null);
+  const [riddleGreeting, setRiddleGreeting] = useState(null); // the monster's in-character justification
   const [riddle, setRiddle] = useState(null);
   const [isJudgingAnswer, setIsJudgingAnswer] = useState(false);
-  const [riddleResult, setRiddleResult] = useState(null); // { correct, verdict }
+  const [riddleResult, setRiddleResult] = useState(null); // { correct, response } - the monster's spoken reaction
 
   // Exit state - set when the party takes an exit path
   const [exitText, setExitText] = useState(null);
@@ -47,6 +48,7 @@ export function useDungeonState() {
   const clearEncounter = useCallback(() => {
     setEncounterText('');
     setEncounterMonster(null);
+    setRiddleGreeting(null);
     setRiddle(null);
     setIsJudgingAnswer(false);
     setRiddleResult(null);
@@ -62,6 +64,7 @@ export function useDungeonState() {
     setArePathsReady(false);
     setEncounterText('');
     setEncounterMonster(null);
+    setRiddleGreeting(null);
     setRiddle(null);
     setIsJudgingAnswer(false);
     setRiddleResult(null);
@@ -79,6 +82,7 @@ export function useDungeonState() {
       arePathsReady,
       encounterText,
       encounterMonster,
+      riddleGreeting,
       riddle,
       isJudgingAnswer,
       riddleResult,
@@ -94,6 +98,7 @@ export function useDungeonState() {
       setArePathsReady,
       setEncounterText,
       setEncounterMonster,
+      setRiddleGreeting,
       setRiddle,
       setIsJudgingAnswer,
       setRiddleResult,

--- a/frontend/src/components/dungeon/components/RiddleBox.js
+++ b/frontend/src/components/dungeon/components/RiddleBox.js
@@ -1,9 +1,10 @@
-// RiddleBox.js - The riddle challenge: question, answer input, and verdict
-// Appears once the monster has asked its riddle (choose_path completes)
-// Handles: typing an answer, judging state, verdict display, and continuing on
+// RiddleBox.js - The monster's challenge: greeting, riddle, answer, and reaction
+// Everything is the monster speaking to the party in character - it greets
+// them with its own reason for the challenge, and it responds to their
+// answer in its own voice (no plain right/wrong checkmark)
 
 import React, { useState } from 'react';
-import { Card, CardSection, Button, Alert, Input, LoadingSpinner } from '../../../shared/ui/index.js';
+import { Card, CardSection, Button, Input, LoadingSpinner } from '../../../shared/ui/index.js';
 import { useNavigation } from '../../../app/contexts/NavigationContext/index.js';
 import { useDungeon } from '../../../app/contexts/DungeonContext/useDungeon.js';
 
@@ -12,7 +13,16 @@ import { useDungeon } from '../../../app/contexts/DungeonContext/useDungeon.js';
  * The first bit of real gameplay: answer the monster's riddle
  */
 function RiddleBox() {
-  const { riddle, isJudgingAnswer, riddleResult, answerRiddle, continueExploring, exitText } = useDungeon();
+  const {
+    encounterMonster,
+    riddleGreeting,
+    riddle,
+    isJudgingAnswer,
+    riddleResult,
+    answerRiddle,
+    continueExploring,
+    exitText
+  } = useDungeon();
   const { navigateToGameScreen } = useNavigation();
 
   const [answer, setAnswer] = useState('');
@@ -20,6 +30,7 @@ function RiddleBox() {
   if (exitText || !riddle) return null;
 
   const hasResult = !!riddleResult;
+  const monsterName = encounterMonster?.name || 'The monster';
 
   // Submit the answer (form wrapper so Enter submits too)
   const handleSubmit = (e) => {
@@ -34,7 +45,8 @@ function RiddleBox() {
     navigateToGameScreen('dungeon-doors');
   };
 
-  const riddleTextStyles = {
+  // Everything the monster says shares one voice
+  const monsterSpeechStyles = {
     fontSize: 'var(--font-size-lg)',
     lineHeight: 'var(--line-height-relaxed)',
     color: 'var(--color-text-primary)',
@@ -45,14 +57,21 @@ function RiddleBox() {
 
   return (
     <Card size="xl" background="light">
-      <CardSection type="header" size="lg" title="🧩 The monster speaks..." alignment="center" />
+      <CardSection type="header" size="lg" title={`🗣️ ${monsterName} speaks...`} alignment="center" />
+
+      {/* The monster's greeting - why it challenges the party */}
+      {riddleGreeting && (
+        <CardSection type="content" alignment="center">
+          <p style={monsterSpeechStyles}>"{riddleGreeting}"</p>
+        </CardSection>
+      )}
 
       {/* The riddle itself */}
       <CardSection type="content" alignment="center">
-        <p style={riddleTextStyles}>"{riddle}"</p>
+        <p style={{ ...monsterSpeechStyles, fontWeight: 'bold' }}>"{riddle}"</p>
       </CardSection>
 
-      {/* Answer input - until a verdict is in */}
+      {/* Answer input - until the monster has responded */}
       {!hasResult && (
         <CardSection type="content" alignment="center">
           <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '12px', justifyContent: 'center', flexWrap: 'wrap' }}>
@@ -60,7 +79,7 @@ function RiddleBox() {
               <Input
                 value={answer}
                 onChange={(e) => setAnswer(e.target.value)}
-                placeholder="Type your answer..."
+                placeholder="Speak your answer..."
               />
             </div>
             <Button
@@ -72,7 +91,7 @@ function RiddleBox() {
               {isJudgingAnswer ? (
                 <>
                   <span style={{ marginRight: '8px' }}><LoadingSpinner size="sm" type="spin" /></span>
-                  Judging...
+                  {monsterName} considers...
                 </>
               ) : (
                 'Answer'
@@ -82,17 +101,14 @@ function RiddleBox() {
         </CardSection>
       )}
 
-      {/* Verdict */}
+      {/* The monster responds to the party's answer, in its own voice */}
       {hasResult && (
-        <CardSection type="content" alignment="center">
-          <Alert
-            type={riddleResult.correct ? 'success' : 'error'}
-            title={riddleResult.correct ? '✅ Correct!' : '❌ Wrong!'}
-          >
-            {riddleResult.verdict}
-          </Alert>
+        <>
+          <CardSection type="content" alignment="center">
+            <p style={monsterSpeechStyles}>"{riddleResult.response}"</p>
+          </CardSection>
 
-          <div style={{ marginTop: '20px' }}>
+          <CardSection type="content" alignment="center">
             <Button
               size="xl"
               icon="🧭"
@@ -101,8 +117,8 @@ function RiddleBox() {
             >
               Continue Exploring
             </Button>
-          </div>
-        </CardSection>
+          </CardSection>
+        </>
       )}
     </Card>
   );


### PR DESCRIPTION
Three refinements to the encounter loop from playtesting feedback:

- Destinations are generated WITH the paths (hidden alongside events in dungeon state, stripped by get_public_paths), so arrival displays instantly when a path is chosen instead of waiting on an LLM call
- Paths come from ONE over-generated batch call (path_choices template asks for 6, we keep the last 2-4): small local LLMs repeat themselves early, so taking the later entries fixes duplicate paths by playing to the model's strengths rather than asking it to be creative
- The encounter is now the monster talking to the party: the riddle template produces an in-character greeting with the monster's own justification for the challenge (guardian, trade, test...), and the judgement responds as the monster speaking to the party instead of a right/wrong checkmark. Both prompts receive the full party details (get_party_details in game/state/manager.py) so the monster can address specific members - groundwork for future LLM-decided consequences (reward, fight, join the party, ...)