### PR TITLE
Fix missing React keys on PartyDisplay empty party slots

### DIFF
--- a/frontend/src/components/cardDisplays/PartyDisplay.js
+++ b/frontend/src/components/cardDisplays/PartyDisplay.js
@@ -83,7 +83,7 @@ function PartyDisplay({
 
             {/* Render empty slot placeholders */}
             {emptySlots.map((_, index) => (
-              <EmptyPartySlot size={cardSize}></EmptyPartySlot>
+              <EmptyPartySlot key={`empty-${index}`} size={cardSize} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## What changed

`PartyDisplay` rendered its empty-companion-slot placeholders in a `.map()` without a `key`, so React logged **"Each child in a list should have a unique key prop. Check the render method of PartyDisplay"** on the home base screen whenever the party had an open seat. The mapped `EmptyPartySlot` now gets `key={`empty-${index}`}` (index keys are safe here — the slots are identical stateless placeholders that never reorder). One line changed.

## Why

Console noise on every home-base visit with a non-full party, and unkeyed lists make React fall back to positional reconciliation. Surfaced while soaking the follower/party-seat changes that merged in #169.

## Verification

- Frontend jest suite: 3 suites / 19 tests pass. (Heads-up: running `npm test` from a `.claude/worktrees/*` checkout reports "No tests found" — jest mishandles dot-directories in the rootDir glob; it needed an explicit absolute `--testMatch`. Runs normally from the main checkout.)
- Live check: backend + frontend up, Continue → home base with "you + 1/3 companions" — the two dashed empty slots render and the key warning is gone from the console (other React dev warnings still come through that channel, so the absence is meaningful).
- Prettier-clean content-wise (`--end-of-line auto`); the plain `npx prettier --check src` currently flags every file on Windows checkouts due to the pre-existing CRLF/`endOfLine` mismatch, unrelated to this change.

## Reviewer notes

This rides `feature/cloud-generation` because that's the session worktree's checked-out branch — #169 already merged, so this PR contains only this single follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)