### PR TITLE
Fix prettier --check failing on CRLF checkouts (endOfLine: auto)

### DIFF
--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "printWidth": 100
+  "printWidth": 100,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## What changed

Added `endOfLine: auto` to `frontend/.prettierrc.json`.

## Why

The documented convention command (`npx prettier --check src` from `frontend/`, per CLAUDE.md) failed on **all 259 files** on Windows: `core.autocrlf=true` checks files out with CRLF, while the config left prettier''s default `endOfLine: lf` in effect. Content-wise the tree was already clean — only the line endings were flagged. With `auto`, prettier validates each file against its own existing line endings, so the check now passes on CRLF working trees.

## Reviewer notes

- **CI stays green**: the frontend job in `ci.yml` runs the same `npx prettier --check src` on `ubuntu-latest`, where checkouts are LF (the index is LF-normalized and there''s no `.gitattributes`). `auto` accepts uniform LF the same way it accepts uniform CRLF. The passing Windows run proves the content itself is format-clean, which is the only other thing the Linux check could trip on.
- Verified before/after locally: 259 files flagged → `All matched files use Prettier code style!` (exit 0).
- The stricter alternative (a `.gitattributes` with `* text=auto eol=lf` + renormalization) was deliberately not taken — it rewrites the working tree for no formatting benefit here.
- CLAUDE.md is untouched: the documented command itself didn''t change, it just works now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)