### PR TITLE
Fix React maxHeight warning: Table honors the prop via Scroll

### DIFF
--- a/frontend/src/shared/ui/Scroll/scroll.css
+++ b/frontend/src/shared/ui/Scroll/scroll.css
@@ -140,6 +140,21 @@
   padding: 0;
 }
 
+/* Table content (Table's maxHeight prop) — the table brings its own frame,
+ * fonts, and cell spacing, so strip Scroll's text-oriented chrome and leave
+ * only the scrolling viewport */
+.scroll-table {
+  background: transparent;
+  border: none;
+}
+
+.scroll-table .scroll-content {
+  padding: 0;
+  font-family: inherit;
+  line-height: inherit;
+  white-space: normal;
+}
+
 /* ===== EMPTY STATE ===== */
 
 .scroll-empty {

--- a/frontend/src/shared/ui/Table/Table.js
+++ b/frontend/src/shared/ui/Table/Table.js
@@ -3,6 +3,7 @@
 // Automatically truncates content to prevent horizontal overflow
 
 import React from 'react';
+import { Scroll } from '../Scroll/index.js';
 import './table.css';
 
 /**
@@ -29,6 +30,7 @@ import './table.css';
  * @param {boolean} props.striped - Alternating row colors
  * @param {boolean} props.bordered - Show borders
  * @param {boolean} props.hover - Hover effects on rows
+ * @param {string} props.maxHeight - Max height (CSS value like '200px'); taller content scrolls vertically with the header pinned
  * @param {string} props.emptyMessage - Message when no data
  * @param {string} props.className - Additional CSS classes
  * @param {object} props.rest - Additional table attributes
@@ -48,6 +50,7 @@ function Table({
   striped = false,
   bordered = false,
   hover = false,
+  maxHeight = null,
   className = '',
   ...rest
 }) {
@@ -63,65 +66,79 @@ function Table({
     .filter(Boolean)
     .join(' ');
 
-  // Simple API: Generate table from columns/data
-  if (columns && data !== null) {
-    return (
-      <div className="table-container">
-        <table className={tableClasses} {...rest}>
-          {/* Generate header */}
-          <TableHead>
+  // Simple API: Generate table content from columns/data
+  // Manual API: Use provided children as-is
+  const tableContent =
+    columns && data !== null ? (
+      <>
+        {/* Generate header */}
+        <TableHead>
+          <TableRow>
+            {columns.map((col, index) => (
+              <TableHeaderCell
+                key={col.key || index}
+                style={col.width ? { width: col.width } : undefined}
+              >
+                {col.header}
+              </TableHeaderCell>
+            ))}
+          </TableRow>
+        </TableHead>
+
+        {/* Generate body */}
+        <TableBody>
+          {data.length === 0 ? (
             <TableRow>
-              {columns.map((col, index) => (
-                <TableHeaderCell
-                  key={col.key || index}
-                  style={col.width ? { width: col.width } : undefined}
-                >
-                  {col.header}
-                </TableHeaderCell>
-              ))}
+              <TableCell colSpan={columns.length} className="table-empty" truncate={false}>
+                {emptyMessage}
+              </TableCell>
             </TableRow>
-          </TableHead>
+          ) : (
+            data.map((row, rowIndex) => (
+              <TableRow key={row.id || rowIndex}>
+                {columns.map((col, colIndex) => {
+                  const value = row[col.key];
+                  const displayValue = col.render ? col.render(value, row) : value;
 
-          {/* Generate body */}
-          <TableBody>
-            {data.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={columns.length} className="table-empty" truncate={false}>
-                  {emptyMessage}
-                </TableCell>
+                  return (
+                    <TableCell
+                      key={col.key || colIndex}
+                      truncate={col.truncate !== false}
+                      className={col.cellClass || ''}
+                    >
+                      {displayValue}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
-            ) : (
-              data.map((row, rowIndex) => (
-                <TableRow key={row.id || rowIndex}>
-                  {columns.map((col, colIndex) => {
-                    const value = row[col.key];
-                    const displayValue = col.render ? col.render(value, row) : value;
-
-                    return (
-                      <TableCell
-                        key={col.key || colIndex}
-                        truncate={col.truncate !== false}
-                        className={col.cellClass || ''}
-                      >
-                        {displayValue}
-                      </TableCell>
-                    );
-                  })}
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </table>
-      </div>
+            ))
+          )}
+        </TableBody>
+      </>
+    ) : (
+      children
     );
-  }
 
-  // Manual API: Use provided children
+  const table = (
+    <table className={tableClasses} {...rest}>
+      {tableContent}
+    </table>
+  );
+
+  // WHY delegate to Scroll instead of styling overflow here: scrolling (custom
+  // scrollbars, overflow rules) is Scroll's one concept — Table only decides
+  // WHEN to scroll. The Scroll viewport sits inside .table-container so the
+  // table keeps its frame while rows scroll within it; the scroll-table
+  // content type (scroll.css) strips Scroll's text-oriented chrome.
   return (
     <div className="table-container">
-      <table className={tableClasses} {...rest}>
-        {children}
-      </table>
+      {maxHeight ? (
+        <Scroll maxHeight={maxHeight} className="scroll-table">
+          {table}
+        </Scroll>
+      ) : (
+        table
+      )}
     </div>
   );
 }

--- a/frontend/src/shared/ui/Table/table.css
+++ b/frontend/src/shared/ui/Table/table.css
@@ -66,6 +66,20 @@
   text-overflow: ellipsis;
 }
 
+/* ===== SCROLLING TABLES (Table's maxHeight wraps rows in Scroll) ===== */
+
+/* Pin the header while rows scroll beneath it. Sticky lives on the cells, not
+ * .table-head, because Chromium won't stick a thead under border-collapse:
+ * collapse — and collapsed borders don't travel with stuck cells either, so
+ * the header's bottom line is a box-shadow and the background moves onto the
+ * cell (a stuck header must be opaque to cover the rows passing under it). */
+.scroll-table .table-header-cell {
+  position: sticky;
+  top: 0;
+  background: var(--background-light);
+  box-shadow: 0 var(--border-width-thin) 0 var(--background-dark);
+}
+
 /* ===== TABLE SIZES ===== */
 
 .table-sm {

--- a/frontend/src/shared/ui/ui.md
+++ b/frontend/src/shared/ui/ui.md
@@ -572,6 +572,7 @@ export const CARD_SECTION_ALIGNMENT = {
  * @param {boolean} props.striped - Alternating row colors
  * @param {boolean} props.bordered - Show borders
  * @param {boolean} props.hover - Hover effects on rows
+ * @param {string} props.maxHeight - Max height (CSS value like '200px'); taller content scrolls vertically with the header pinned
  * @param {string} props.emptyMessage - Message when no data
  * @param {string} props.className - Additional CSS classes
  * @param {object} props.rest - Additional table attributes


### PR DESCRIPTION
## What changed

`Table` spread unknown props onto the DOM `<table>` element, so the `maxHeight` passed at six call sites (five tables in `StreamingDisplay`, the generation-log table in `ApiServicesTestScreen`) logged React's "does not recognize the maxHeight prop" warning on every app load — and, worse, the intended height caps silently never applied, leaving those tables unbounded.

- **`Table.js`** — `maxHeight` is now a real prop. When set, the rows render inside the shared `Scroll` component within the table frame, so scrolling stays Scroll's one concept and Table only decides when to scroll. The two duplicated return branches (simple/manual API) collapsed into one in the process.
- **`scroll.css`** — new `scroll-table` content type (same extension pattern as `scroll-streaming`/`scroll-code`/`scroll-list`) strips Scroll's text-oriented chrome (mono font, padding, border) so the table keeps its own look.
- **`table.css`** — header cells pin with `position: sticky` while rows scroll; sticky lives on the cells rather than `thead` because Chromium won't stick a thead under `border-collapse: collapse`, and a box-shadow stands in for the bottom border that collapsed borders can't carry along.
- **`ui.md`** — documents the new prop.

No call-site changes were needed: all six existing `maxHeight` usages now behave as originally intended, and `ExpandableTable` (which composes Table's manual API) inherits the capability.

## Verification

- With the fix: zero console warnings/errors from server start through load and reload; all mounted tables sit in `scroll-table` viewports with computed `max-height` applied and no stray `maxheight` DOM attributes.
- A/B: stashing the fix immediately reproduces the warning on unmodified code.
- Forced a real overflow on the developer log table and confirmed rows scroll under the pinned, opaque header.
- Prettier and the CRA/eslint build are clean; no new warnings in touched files.

## Reviewer notes

- Pre-existing and unrelated (found during verification, confirmed via the same stash A/B): the Developer → API Tests screen infinite-loops with "Maximum update depth exceeded" on mount, from the missing-dependency effects in `useGeneration.js` that eslint already flags. Tracked separately.
- Trivial, untouched: `ApiServicesTestScreen` also passes a dead `loading` prop to Table (no warning; its `emptyMessage` already covers the loading text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
