### PR TITLE
Fix useGenerationLogs infinite update loop on the Developer screen

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,8 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["start"],
       "cwd": "frontend",
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     },
     {
       "name": "backend",

--- a/frontend/src/api/services/generation.js
+++ b/frontend/src/api/services/generation.js
@@ -3,7 +3,7 @@
 // Keeps all actual option values exactly as they come from backend
 // Properly converts parameters when sending to backend
 
-import { get, post, getWithParams } from '../core/client.js';
+import { get, getWithParams } from '../core/client.js';
 import { transformGenerationLogs } from '../transformers/generation.js';
 
 // ===== GENERATION LOGS (UNIFIED SYSTEM) =====
@@ -73,7 +73,9 @@ export async function getGenerationLogOptions() {
 }
 
 getGenerationLogOptions.defaults = {
-  filterOptions: [],
+  // filterOptions is an object keyed by filter name (matching the backend's
+  // filter_options shape) — consumers iterate it with Object.keys/Object.entries
+  filterOptions: {},
   sortOptions: {
     fields: [],
     orders: [],

--- a/frontend/src/app/hooks/useGeneration.js
+++ b/frontend/src/app/hooks/useGeneration.js
@@ -27,8 +27,20 @@ export function useGenerationLogs(options = {}) {
   const logsApi = useAsyncState(generationApi.getGenerationLogs);
   const optionsApi = useAsyncState(generationApi.getGenerationLogOptions);
 
+  // Destructured because effects/callbacks below depend on these functions:
+  // useAsyncState keeps execute referentially stable, and depending on it
+  // directly (instead of on the whole logsApi/optionsApi object, which is
+  // rebuilt every render) is what lets the dependency arrays stay honest.
+  const { execute: fetchLogs } = logsApi;
+  const { execute: fetchOptions } = optionsApi;
+
   // ===== SIMPLE STATE MANAGEMENT =====
-  const [filters, setFilters] = useState({});
+  // filters starts as null, NOT {} — "filter names unknown until options
+  // arrive" must be distinguishable from "initialized", or the init effect
+  // below could re-fire forever (that exact loop used to crash this hook
+  // with "Maximum update depth exceeded"). Consumers never see the null:
+  // the return block substitutes {}.
+  const [filters, setFilters] = useState(null);
   const [sortValues, setSortValues] = useState({
     field: 'id',
     order: 'desc',
@@ -42,22 +54,34 @@ export function useGenerationLogs(options = {}) {
     initialPage: 1,
   });
 
+  // Only these pieces of pagination participate in dependency arrays — the
+  // pagination object itself is rebuilt every render, so depending on it
+  // would recreate every callback on every render.
+  const { currentOffset, firstPage, setLimit: setPaginationLimit } = pagination;
+
   // ===== AUTO-LOAD OPTIONS AND INITIALIZE FILTERS =====
   useEffect(() => {
-    optionsApi.execute();
-  }, [optionsApi.execute]);
+    fetchOptions();
+  }, [fetchOptions]);
 
   // Initialize filters when options load (completely dynamic!)
-  // This makes the hook work with ANY backend that provides filterOptions
+  // This makes the hook work with ANY backend that provides filterOptions.
+  // Gated on isSuccess rather than on the data: before the fetch resolves,
+  // data holds placeholder defaults that must not be mistaken for real
+  // options. The functional update returns the existing state untouched once
+  // initialized, so this effect cannot re-trigger itself.
   useEffect(() => {
-    if (optionsApi.data.filterOptions && Object.keys(filters).length === 0) {
+    if (!optionsApi.isSuccess) return;
+    const loadedFilterOptions = optionsApi.data.filterOptions || {};
+    setFilters((currentFilters) => {
+      if (currentFilters !== null) return currentFilters;
       const initialFilters = {};
-      Object.keys(optionsApi.data.filterOptions).forEach((filterName) => {
+      Object.keys(loadedFilterOptions).forEach((filterName) => {
         initialFilters[filterName] = 'all';
       });
-      setFilters(initialFilters);
-    }
-  }, [optionsApi.data.filterOptions, filters]);
+      return initialFilters;
+    });
+  }, [optionsApi.isSuccess, optionsApi.data.filterOptions]);
 
   // ===== ENHANCED OPTIONS FOR FilterSelectGroup =====
   const filterOptions = useMemo(() => {
@@ -90,11 +114,13 @@ export function useGenerationLogs(options = {}) {
   const loadData = useCallback(() => {
     const params = {
       limit,
-      offset: pagination.currentOffset,
+      offset: currentOffset,
     };
 
     // Add non-"all" filters (completely dynamic!)
-    Object.entries(filters).forEach(([key, value]) => {
+    // filters can still be null if this is called before options load
+    // (e.g. refresh() clicked early) — treat that as "no filters"
+    Object.entries(filters ?? {}).forEach(([key, value]) => {
       if (value && value !== 'all') {
         params[key] = value;
       }
@@ -104,39 +130,40 @@ export function useGenerationLogs(options = {}) {
     params.sortBy = sortValues.field;
     params.sortOrder = sortValues.order;
 
-    logsApi.execute(params);
-  }, [logsApi.execute, limit, pagination.currentOffset, filters, sortValues]);
+    fetchLogs(params);
+  }, [fetchLogs, limit, currentOffset, filters, sortValues]);
 
-  // Auto-load when dependencies change (wait for filters to be initialized)
+  // Auto-load when dependencies change (wait for filters to be initialized,
+  // so the first fetch isn't duplicated a moment later by the filter init)
   useEffect(() => {
-    if (autoLoad && optionsApi.data.filterOptions && Object.keys(filters).length > 0) {
+    if (autoLoad && filters !== null) {
       loadData();
     }
-  }, [loadData, autoLoad, optionsApi.data.filterOptions, filters]);
+  }, [autoLoad, filters, loadData]);
 
   // ===== SIMPLE EVENT HANDLERS =====
   const handleFilterChange = useCallback(
     (fieldName, newValue, updatedValues) => {
       setFilters(updatedValues);
-      pagination.firstPage(); // Reset to first page
+      firstPage(); // Reset to first page
     },
-    [pagination],
+    [firstPage],
   );
 
   const handleSortChange = useCallback(
     (fieldName, newValue, updatedValues) => {
       setSortValues(updatedValues);
-      pagination.firstPage(); // Reset to first page
+      firstPage(); // Reset to first page
     },
-    [pagination],
+    [firstPage],
   );
 
   const handleLimitChange = useCallback(
     (newLimit) => {
       setLimit(newLimit);
-      pagination.setLimit(newLimit);
+      setPaginationLimit(newLimit);
     },
-    [pagination],
+    [setPaginationLimit],
   );
 
   const refresh = useCallback(() => {
@@ -151,9 +178,9 @@ export function useGenerationLogs(options = {}) {
         clearedFilters[filterName] = 'all';
       });
       setFilters(clearedFilters);
-      pagination.firstPage();
+      firstPage();
     }
-  }, [pagination, optionsApi.data.filterOptions]);
+  }, [optionsApi.data.filterOptions, firstPage]);
 
   return {
     // ===== DATA =====
@@ -165,7 +192,7 @@ export function useGenerationLogs(options = {}) {
     sortOptions, // Formatted for FilterSelectGroup
 
     // ===== CURRENT STATE =====
-    filters, // Current filter values
+    filters: filters ?? {}, // Current filter values (always an object for consumers)
     sortValues, // Current sort values
     limit, // Current page size
 


### PR DESCRIPTION
## What

Fixes the long-standing "Maximum update depth exceeded" flood on the Developer screen. Both tabs that use `useGenerationLogs` were affected: **Overview** (`AiLogTableContainer`) and **API Tests** (`ApiServicesTestScreen`) re-rendered in an infinite loop from the moment they mounted.

## Root cause

Not the eslint-flagged `execute` deps (those are referentially stable) — the loop was in the filter-init effect in `useGeneration.js`:

- `getGenerationLogOptions.defaults.filterOptions` was `[]` — a **truthy** empty array — so before the options fetch resolved, the effect saw "options present, filters empty" and ran.
- It called `setFilters({})` with a fresh object each pass, and `filters` was in its own dependency array, so every new identity re-fired the effect. The guard (`Object.keys(filters).length === 0`) could never close.

## Fix (hook + service layer)

- `filters` starts as `null` ("filter names not known yet"), distinguishable from "initialized". Consumers still receive `{}` via the return, so neither screen needed changes.
- The init effect gates on `optionsApi.isSuccess` (the async state machine's own signal, not data truthiness) and uses a functional update that returns the existing state untouched once initialized — structurally incapable of self-retriggering.
- The auto-load effect waits for `filters !== null`, so mounting fires exactly one options fetch and one logs fetch (no duplicate first fetch).
- Effects/callbacks now depend on the destructured stable `execute` functions and on `pagination`'s stable pieces (`firstPage`, `setLimit`, `currentOffset`) instead of per-render objects. Both `react-hooks/exhaustive-deps` warnings for this file are gone from the CRA compile output — fixed, not suppressed.
- `generation.js`: placeholder default is now `filterOptions: {}` to match the shape consumers iterate (`Object.keys`/`Object.entries`); dropped an unused `post` import.
- `.claude/launch.json`: `autoPort: true` on the frontend config so a second dev session can start when :3000 is taken (CRA honors the assigned `PORT`).

## Verification

With backend + frontend running, clicked through both Developer tabs:

- Console: **zero** "Maximum update depth exceeded" entries.
- Network: Overview mount = 1 `log-options` + 1 `logs?limit=20`; API Tests mount = 1 `log-options` + 1 `logs?limit=10`; changing Generation Type to `llm` fired exactly **one** refetch and the screen updated (744 -> 713 logs, 75 -> 72 pages).
- Filters initialize from real backend names: `{"generation_type":"all","priority":"all","prompt_name":"all","prompt_type":"all","status":"all"}`.
- `npm test`: 24/24 pass; prettier clean; no new eslint warnings.

## Notes for review

- Remaining console noise on this screen is pre-existing and out of scope: the `maxHeight` DOM-prop warning (Table `maxHeight` work in flight elsewhere) and an ExpandableTable `loading`-prop warning (follow-up task filed).
- Verification detour worth knowing: on a non-3000 port, all REST calls fail CORS because `config.js` hardcodes `BASE_URL: http://localhost:5000` and backend CORS only admits `:3000`. I verified through the CRA proxy via a temporary local change (reverted; not in this diff) and filed a follow-up task to route dev API calls through the proxy properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
