### PR TITLE
ExpandableTable consumes the loading prop (fixes Developer-screen React warning)

### DIFF
--- a/frontend/src/components/developer/AiLogTable/AiLogTableView.js
+++ b/frontend/src/components/developer/AiLogTable/AiLogTableView.js
@@ -244,7 +244,7 @@ function AiLogTableView({
             data={logs}
             expandableRows={expandableRows}
             renderExpandedContent={renderExpandedContent}
-            emptyMessage={isLoading ? 'Loading...' : 'No logs found'}
+            emptyMessage="No logs found"
             size="sm"
             striped
             hover

--- a/frontend/src/shared/ui/ExpandableTable/ExpandableTable.js
+++ b/frontend/src/shared/ui/ExpandableTable/ExpandableTable.js
@@ -3,14 +3,8 @@
 // Works seamlessly with existing pagination and maintains responsive behavior
 
 import React from 'react';
-import {
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableHeaderCell,
-  TableCell,
-} from '../Table/index.js';
+import { TableHead, TableBody, TableRow, TableHeaderCell, TableCell } from '../Table/index.js';
+import { LoadingSpinner } from '../LoadingStates/index.js';
 import ExpandableTableRow from './ExpandableTableRow.js';
 import './expandableTable.css';
 
@@ -25,6 +19,7 @@ import './expandableTable.css';
  * @param {Function} props.renderExpandedContent - Function to render expanded content: (row) => ReactElement
  * @param {string} props.expandIconColumn - Column key to show expand icon (default: first column)
  * @param {string} props.emptyMessage - Message when no data (default: 'No data available')
+ * @param {boolean} props.loading - Show a loading spinner row instead of body rows (default: false)
  * @param {string} props.size - Table size (sm, md, lg) (default: 'md')
  * @param {boolean} props.striped - Alternating row colors (default: false)
  * @param {boolean} props.bordered - Show borders (default: false)
@@ -44,6 +39,7 @@ function ExpandableTable({
   // Optional configuration
   expandIconColumn = null, // Auto-detect first column if null
   emptyMessage = 'No data available',
+  loading = false,
 
   // Table styling (same as existing Table)
   size = 'md',
@@ -85,33 +81,45 @@ function ExpandableTable({
     .filter(Boolean)
     .join(' ');
 
-  // Handle empty state
-  if (data.length === 0) {
-    return (
-      <div className="table-container">
-        <table className={tableClasses} {...rest}>
-          <TableHead>
-            <TableRow>
-              {columns.map((col, index) => (
-                <TableHeaderCell
-                  key={col.key || index}
-                  style={col.width ? { width: col.width } : undefined}
-                >
-                  {col.header}
-                </TableHeaderCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            <TableRow>
-              <TableCell colSpan={columns.length} className="table-empty" truncate={false}>
-                {emptyMessage}
-              </TableCell>
-            </TableRow>
-          </TableBody>
-        </table>
-      </div>
+  // Body content: loading spinner row, empty-message row, or the data rows.
+  // WHY status rows instead of swapping out the whole table: the header keeps
+  // its shape (same treatment Table gives emptyMessage), so the layout doesn't
+  // jump when rows arrive.
+  let bodyContent;
+  if (loading) {
+    bodyContent = (
+      <TableRow>
+        <TableCell
+          colSpan={columns.length}
+          className="table-empty expandable-table-loading-cell"
+          truncate={false}
+        >
+          <LoadingSpinner size="sm" ariaLabel="Loading rows" />
+          Loading...
+        </TableCell>
+      </TableRow>
     );
+  } else if (data.length === 0) {
+    bodyContent = (
+      <TableRow>
+        <TableCell colSpan={columns.length} className="table-empty" truncate={false}>
+          {emptyMessage}
+        </TableCell>
+      </TableRow>
+    );
+  } else {
+    bodyContent = data.map((row, rowIndex) => (
+      <ExpandableTableRow
+        key={row.id || rowIndex}
+        row={row}
+        rowIndex={rowIndex}
+        columns={columns}
+        expandableRows={expandableRows}
+        renderExpandedContent={renderExpandedContent}
+        iconColumnKey={iconColumnKey}
+        animateExpansion={animateExpansion}
+      />
+    ));
   }
 
   return (
@@ -131,21 +139,7 @@ function ExpandableTable({
           </TableRow>
         </TableHead>
 
-        {/* Table Body with Expandable Rows */}
-        <TableBody>
-          {data.map((row, rowIndex) => (
-            <ExpandableTableRow
-              key={row.id || rowIndex}
-              row={row}
-              rowIndex={rowIndex}
-              columns={columns}
-              expandableRows={expandableRows}
-              renderExpandedContent={renderExpandedContent}
-              iconColumnKey={iconColumnKey}
-              animateExpansion={animateExpansion}
-            />
-          ))}
-        </TableBody>
+        <TableBody>{bodyContent}</TableBody>
       </table>
     </div>
   );

--- a/frontend/src/shared/ui/ExpandableTable/__tests__/ExpandableTable.test.js
+++ b/frontend/src/shared/ui/ExpandableTable/__tests__/ExpandableTable.test.js
@@ -1,0 +1,161 @@
+// ExpandableTable tests - the loading prop must be consumed, never spread
+// onto the DOM <table>. Regression coverage for the React warning
+// "Received `false` for a non-boolean attribute `loading`" that fired on the
+// Developer screen (AiLogTableView passes loading={isLoading}), plus coverage
+// for the three body states (loading row / empty row / data rows).
+//
+// WHY bare react-dom instead of @testing-library/react: the project has no
+// testing-library dependency, and node_modules must not be touched from a
+// worktree checkout, so these tests use only what react-scripts already ships.
+
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import ExpandableTable from '../ExpandableTable.js';
+
+// createRoot outside of testing-library requires opting in to act()
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+const COLUMNS = [
+  { key: 'id', header: 'ID' },
+  { key: 'name', header: 'Name' },
+];
+
+const DATA = [
+  { id: 1, name: 'Emberwing' },
+  { id: 2, name: 'Mosslurker' },
+];
+
+// Minimal stand-in for the useExpandableRows hook result - ExpandableTable
+// and ExpandableTableRow only call these two members
+function makeExpandableRows(expandedIds = []) {
+  return {
+    isRowExpanded: (id) => expandedIds.includes(id),
+    toggleRow: jest.fn(),
+  };
+}
+
+function renderExpandedContent(row) {
+  return <div className="test-expanded-content">Details for {row.name}</div>;
+}
+
+describe('ExpandableTable', () => {
+  let container;
+  let root;
+
+  function render(element) {
+    // The no-unnecessary-act rule assumes Testing Library's auto-acting
+    // render; with bare createRoot, React requires the act() wrapper.
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      root.render(element);
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  test('consumes loading instead of spreading it onto the <table> (no React warning)', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ExpandableTable
+        columns={COLUMNS}
+        data={DATA}
+        expandableRows={makeExpandableRows()}
+        renderExpandedContent={renderExpandedContent}
+        loading={false}
+      />,
+    );
+
+    // Direct DOM proof: the attribute never reaches the element
+    const table = container.querySelector('table');
+    expect(table).not.toBeNull();
+    expect(table.hasAttribute('loading')).toBe(false);
+
+    // And React never had to complain about it
+    const warnings = errorSpy.mock.calls.map((args) => String(args[0]));
+    expect(warnings.filter((message) => message.includes('non-boolean attribute'))).toEqual([]);
+
+    errorSpy.mockRestore();
+  });
+
+  test('still forwards legitimate extra attributes through ...rest', () => {
+    render(
+      <ExpandableTable
+        columns={COLUMNS}
+        data={DATA}
+        expandableRows={makeExpandableRows()}
+        renderExpandedContent={renderExpandedContent}
+        data-testid="log-table"
+      />,
+    );
+
+    expect(container.querySelector('table').getAttribute('data-testid')).toBe('log-table');
+  });
+
+  test('loading replaces body rows with the spinner status row', () => {
+    render(
+      <ExpandableTable
+        columns={COLUMNS}
+        data={DATA}
+        expandableRows={makeExpandableRows()}
+        renderExpandedContent={renderExpandedContent}
+        loading
+      />,
+    );
+
+    const loadingCell = container.querySelector('.expandable-table-loading-cell');
+    expect(loadingCell).not.toBeNull();
+    expect(loadingCell.querySelector('.loading-spinner')).not.toBeNull();
+    expect(loadingCell.textContent).toContain('Loading');
+
+    // The status row spans the full table and stands in for the data rows,
+    // while the header keeps its shape
+    expect(loadingCell.getAttribute('colspan')).toBe(String(COLUMNS.length));
+    expect(container.querySelectorAll('.expandable-row')).toHaveLength(0);
+    expect(container.querySelectorAll('th')).toHaveLength(COLUMNS.length);
+  });
+
+  test('shows the empty message when not loading and there is no data', () => {
+    render(
+      <ExpandableTable
+        columns={COLUMNS}
+        data={[]}
+        expandableRows={makeExpandableRows()}
+        renderExpandedContent={renderExpandedContent}
+        emptyMessage="No logs found"
+      />,
+    );
+
+    expect(container.querySelector('.table-empty').textContent).toBe('No logs found');
+    expect(container.querySelector('.expandable-table-loading-cell')).toBeNull();
+  });
+
+  test('renders data rows and expanded content for expanded rows', () => {
+    render(
+      <ExpandableTable
+        columns={COLUMNS}
+        data={DATA}
+        expandableRows={makeExpandableRows([2])}
+        renderExpandedContent={renderExpandedContent}
+        animateExpansion={false}
+      />,
+    );
+
+    expect(container.querySelectorAll('.expandable-row')).toHaveLength(DATA.length);
+    expect(container.querySelector('.test-expanded-content').textContent).toBe(
+      'Details for Mosslurker',
+    );
+  });
+});

--- a/frontend/src/shared/ui/ExpandableTable/expandableTable.css
+++ b/frontend/src/shared/ui/ExpandableTable/expandableTable.css
@@ -143,6 +143,16 @@
   margin: var(--spacing-sm);
 }
 
+/* ===== LOADING STATE ===== */
+
+/* Spinner + label sit side by side inside the status row; .table-empty
+ * (table.css) already supplies the centered dim-italic status treatment. */
+.expandable-table-loading-cell .cell-content {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
 /* ===== SIZE VARIATIONS ===== */
 
 .expandable-table-sm .expand-icon {

--- a/frontend/src/shared/ui/ui.md
+++ b/frontend/src/shared/ui/ui.md
@@ -599,6 +599,7 @@ export const TABLE_SIZES = {
  * @param {Function} props.renderExpandedContent - Function to render expanded content: (row) => ReactElement
  * @param {string} props.expandIconColumn - Column key to show expand icon (default: first column)
  * @param {string} props.emptyMessage - Message when no data (default: 'No data available')
+ * @param {boolean} props.loading - Show a loading spinner row instead of body rows (default: false)
  * @param {string} props.size - Table size (sm, md, lg) (default: 'md')
  * @param {boolean} props.striped - Alternating row colors (default: false)
  * @param {boolean} props.bordered - Show borders (default: false)


### PR DESCRIPTION
## What

The Developer screen's Overview tab logged a React warning for every render of the generation-log table:

> Warning: Received `false` for a non-boolean attribute `loading`.

`AiLogTableView` passes `loading={isLoading}` to `ExpandableTable`, which spread every unrecognized prop onto the DOM `<table>` element. `ExpandableTable` now consumes the prop and gives it real behavior:

- **`loading` renders a spinner status row** (LoadingSpinner + "Loading...") in place of the body rows, reusing the `.table-empty` treatment the empty state already uses — the header keeps its shape, so nothing jumps when rows arrive.
- The body now has three explicit states (loading / empty / data), which also removes the header markup that was duplicated between the old empty and data branches, and drops an unused `Table` import.
- `AiLogTableView` no longer overloads `emptyMessage` as a loading message (`ExpandableTable` owns loading presentation now).
- `ui.md` documents the new prop.
- New jest suite (`ExpandableTable/__tests__/`) locks the regression — no `loading` attribute on `<table>`, no non-boolean console warning — plus the spinner row, empty state, `...rest` passthrough for legitimate attributes, and row expansion. Written with bare `react-dom` `createRoot`/`act`; no new dependencies.

## Verification

- Live on Developer → Overview with backend + frontend running: table mounted with 20 real log rows, the `<table>` element carries no `loading` attribute, and a fresh 1,402-line console buffer contains **zero** non-boolean-attribute warnings. Row expansion works after the restructure.
- `npm test`: 29/29 across 4 suites. Prettier and eslint clean; 500-line ceiling check passes.

## Reviewer notes

- The **"Maximum update depth exceeded" flood** you'll see on the Developer screen is the pre-existing `useGenerationLogs` loop — that's #173, not this PR. Until it merges, the Developer screen is flaky on any branch cut from main; this change neither causes nor fixes that.
- The shared `Table` component's similar `maxHeight` warning was handled separately (#172); `Table` is untouched here.
- The loading row won't currently appear on the Overview tab because `AiLogTableView` swaps in its own full-size spinner while fetching — the prop is consumed and functional regardless, and the warning is gone.
- One line-scoped eslint disable in the test file: `testing-library/no-unnecessary-act` misfires because the project doesn't use Testing Library, and bare `createRoot` requires the `act()` wrapper it flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
