### PR TITLE
Dev API uses relative URLs through the CRA proxy (any port, no CORS)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,8 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["start"],
       "cwd": "frontend",
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     },
     {
       "name": "backend",

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,6 @@
 import os
 
 from flask import Flask
-from flask_cors import CORS
 
 
 def create_app(config_name='development'):
@@ -25,8 +24,10 @@ def create_app(config_name='development'):
     app = Flask(__name__)
     _configure_app(app)
 
-    # Enable CORS for React frontend
-    CORS(app, origins=['http://localhost:3000'])
+    # No CORS setup on purpose: the React dev server proxies /api calls here
+    # (frontend/package.json "proxy"), so the browser only ever makes
+    # same-origin requests - on any dev-server port. Cross-origin headers
+    # would be dead weight.
 
     # Initialize database
     from backend.startup import initialize_database

--- a/backend/routes/sse_routes.py
+++ b/backend/routes/sse_routes.py
@@ -47,8 +47,11 @@ def stream_events():
             sse_service.remove_connection(connection.id)
 
     response = Response(event_generator(), mimetype='text/event-stream')
-    response.headers['Cache-Control'] = 'no-cache'
+    # no-transform matters: the CRA dev proxy gzip-compresses responses by
+    # default, and gzip would buffer the event stream into silence - this
+    # tells every intermediary to pass events through untouched. The stream
+    # is same-origin through that proxy, so no Access-Control header needed.
+    response.headers['Cache-Control'] = 'no-cache, no-transform'
     response.headers['Connection'] = 'keep-alive'
-    response.headers['Access-Control-Allow-Origin'] = '*'
 
     return response

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,6 +16,11 @@ links to the per-domain files.
 
 ## Base URL
 - Development: `http://localhost:5000/api`
+- The frontend never hardcodes that address: in development it makes
+  relative `/api/...` requests (REST, SSE, and card-art images alike) and
+  the CRA dev server's proxy (`frontend/package.json` `"proxy"`) forwards
+  them to `:5000`. Everything stays same-origin on any dev-server port, so
+  the backend serves no CORS headers.
 
 ## Standard response format
 Every JSON endpoint returns an envelope:

--- a/frontend/src/api/core/config.js
+++ b/frontend/src/api/core/config.js
@@ -2,9 +2,22 @@
 // Updated to match complete backend API reference guide
 // Centralizes URLs, timeouts, and endpoint definitions
 
+// Where API requests go.
+// Development: '' (relative URLs) so REST calls, the SSE stream, uploads,
+// and <img> card art all stay same-origin and ride the CRA dev-server proxy
+// (package.json "proxy" -> http://localhost:5000). Same-origin means any
+// dev-server port works (parallel sessions auto-pick ports) and the backend
+// needs no CORS headers.
+// Production: set REACT_APP_API_URL at build time if the API lives on
+// another origin.
+const BASE_URL =
+  process.env.NODE_ENV === 'production'
+    ? process.env.REACT_APP_API_URL || 'http://localhost:5000'
+    : '';
+
 // Base configuration
 export const API_CONFIG = {
-  BASE_URL: 'http://localhost:5000',
+  BASE_URL,
   DEFAULT_TIMEOUT: 600000, // 10 minutes
   DEFAULT_HEADERS: {
     'Content-Type': 'application/json',
@@ -61,7 +74,7 @@ export const API_ENDPOINTS = {
   GENERATION_LOG_OPTIONS: '/api/generation/log-options',
 
   // ===== STREAMING & REAL-TIME =====
-  STREAMING_EVENTS: '/api/streaming/llm-events',
+  SSE_EVENTS: '/api/sse/events',
 
   // ===== TESTING & DEBUG =====
   GAME_TESTER_TESTS: '/api/game_tester/tests',
@@ -79,10 +92,9 @@ export const getApiConfig = () => {
     config.LOG_RESPONSES = true;
   }
 
-  // Production overrides
+  // Production overrides (BASE_URL already resolves REACT_APP_API_URL above)
   if (process.env.NODE_ENV === 'production') {
     config.ENABLE_LOGGING = false;
-    config.BASE_URL = process.env.REACT_APP_API_URL || config.BASE_URL;
   }
 
   return config;

--- a/frontend/src/api/core/interceptors.js
+++ b/frontend/src/api/core/interceptors.js
@@ -61,6 +61,24 @@ export async function processResponse(response, endpoint = 'unknown') {
   try {
     // Check if response is ok
     if (!response.ok) {
+      // "Backend unreachable" detection: the CRA dev proxy reports a dead
+      // backend as a 500 with a plain-text "Proxy error" body (verified -
+      // it does NOT send 502/504), while real backend errors always arrive
+      // as Flask jsonify JSON. 502/504 are the same signal from
+      // production-style gateways.
+      const contentType = response.headers.get('content-type') || '';
+      const backendUnreachable =
+        response.status === 502 ||
+        response.status === 504 ||
+        (response.status === 500 && !contentType.includes('application/json'));
+      if (backendUnreachable) {
+        throw new ApiError(
+          'Backend unreachable - make sure it is running (dev proxies /api to localhost:5000)',
+          response.status,
+          response,
+          endpoint,
+        );
+      }
       throw new ApiError(
         `API request failed: ${response.status} ${response.statusText}`,
         response.status,
@@ -126,8 +144,11 @@ export function processError(error, endpoint = 'unknown') {
   }
 
   if (error.message.includes('Failed to fetch') || error.message.includes('NetworkError')) {
+    // Requests go same-origin (through the dev proxy in development), so a
+    // network-level failure means the server that served the page is gone -
+    // a down BACKEND surfaces as a 502/504 response instead.
     return new ApiError(
-      'Cannot connect to backend server - make sure it is running on localhost:5000',
+      'Cannot connect to the server - request failed before reaching the backend',
       null,
       null,
       endpoint,

--- a/frontend/src/api/core/useSSE.js
+++ b/frontend/src/api/core/useSSE.js
@@ -1,6 +1,9 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
+import { API_CONFIG, API_ENDPOINTS } from './config.js';
 
-const SSE_URL = 'http://localhost:5000/api/sse/events';
+// Same base-URL policy as REST calls: relative in development, so the
+// EventSource stream stays same-origin and rides the CRA proxy to the backend.
+const SSE_URL = `${API_CONFIG.BASE_URL}${API_ENDPOINTS.SSE_EVENTS}`;
 
 export const useSSE = (eventHandlers) => {
   const [isConnected, setIsConnected] = useState(false);

--- a/frontend/src/api/services/monster.js
+++ b/frontend/src/api/services/monster.js
@@ -4,6 +4,7 @@
 // Functions carry their own defaults for perfect pairing with useAsyncState
 
 import { get, post, getWithParams } from '../core/client.js';
+import { API_CONFIG } from '../core/config.js';
 import {
   transformMonster,
   transformMonsters,
@@ -163,12 +164,14 @@ loadMonsterEvolutions.defaults = {
 };
 
 /**
- * Get monster card art file URL
- * Note: This returns the full URL for the card art file endpoint
- * @param {string} relativePath - Relative path from monster.card_art.relative_path
- * @returns {string} Full URL to the card art image endpoint
+ * Build the display URL for a card art image - the ONE place these URLs
+ * come from (player portraits reuse it too; the backend serves both from
+ * the same route). Relative in development so images stay same-origin
+ * through the CRA proxy no matter which port the dev server runs on.
+ * @param {string} relativePath - Relative path from monster.cardArt.relativePath
+ * @returns {string|null} URL for an <img> src, or null when there is no art
  */
 export function getCardArtUrl(relativePath) {
   if (!relativePath) return null;
-  return `http://localhost:5000/api/monsters/card-art/file/${relativePath}`;
+  return `${API_CONFIG.BASE_URL}/api/monsters/card-art/${relativePath}`;
 }

--- a/frontend/src/api/services/player.js
+++ b/frontend/src/api/services/player.js
@@ -6,6 +6,7 @@
 
 import { get, post } from '../core/client.js';
 import { getApiConfig } from '../core/config.js';
+import { getCardArtUrl } from './monster.js';
 import { transformMonster } from '../transformers/monsters.js';
 
 /**
@@ -146,11 +147,11 @@ uploadPortrait.defaults = {
 
 /**
  * Display URL for any portrait candidate path (served by the existing
- * card-art route - uploads and painted candidates live in the same tree)
+ * card-art route - uploads and painted candidates live in the same tree,
+ * so this delegates to the one card-art URL builder)
  * @param {string} relativePath
  * @returns {string|null}
  */
 export function getPortraitUrl(relativePath) {
-  if (!relativePath) return null;
-  return `${getApiConfig().BASE_URL}/api/monsters/card-art/${relativePath}`;
+  return getCardArtUrl(relativePath);
 }

--- a/frontend/src/api/stores/aiStateStore.js
+++ b/frontend/src/api/stores/aiStateStore.js
@@ -2,6 +2,8 @@
 // Manages computed states outside React with useSyncExternalStore infrastructure
 // Each computed state can be subscribed to independently to prevent unnecessary re-renders
 
+import { getCardArtUrl } from '../services/monster.js';
+
 // ===== EXTERNAL STATE STORAGE =====
 let aiState = {
   // Active generation tracking
@@ -291,9 +293,7 @@ export const aiStatusRouter = (eventName, eventData) => {
       });
 
       // Create image URL if we have an image path
-      const imageUrl = eventData.result?.imagePath
-        ? `http://localhost:5000/api/monsters/card-art/${eventData.result.imagePath}`
-        : null;
+      const imageUrl = getCardArtUrl(eventData.result?.imagePath);
 
       updateImageStatus({
         status: 'completed',

--- a/frontend/src/components/cards/MonsterCard.js
+++ b/frontend/src/components/cards/MonsterCard.js
@@ -9,6 +9,7 @@ import MonsterCardOverview from './MonsterCardOverview.js';
 import MonsterCardDetails from './MonsterCardDetails.js';
 import './monsterCard.css';
 import { CARD_SIZES } from '../../shared/constants/constants.js';
+import { getCardArtUrl } from '../../api/services/monster.js';
 
 function MonsterCard({
   monster,
@@ -22,9 +23,9 @@ function MonsterCard({
   hideFlipHint = false,
 }) {
   // Construct card art URL using clean monster object
-  const getCardArtUrl = () => {
-    if (!monster.cardArt.exists || !monster.cardArt.relativePath) return null;
-    return `http://localhost:5000/api/monsters/card-art/${monster.cardArt.relativePath}`;
+  const cardArtUrlForMonster = () => {
+    if (!monster.cardArt.exists) return null;
+    return getCardArtUrl(monster.cardArt.relativePath);
   };
 
   // Handle expand card - just call parent callback
@@ -44,7 +45,7 @@ function MonsterCard({
       size={size}
       showPartyToggle={showPartyToggle}
       onExpandCard={handleExpandCard}
-      getCardArtUrl={getCardArtUrl}
+      getCardArtUrl={cardArtUrlForMonster}
     />
   );
 

--- a/frontend/src/components/chat/MonsterChatPicker.js
+++ b/frontend/src/components/chat/MonsterChatPicker.js
@@ -5,10 +5,11 @@
 import React from 'react';
 import { Card, CardSection, EmptyState, LoadingSpinner } from '../../shared/ui/index.js';
 import { useParty } from '../../app/contexts/PartyContext/index.js';
+import { getCardArtUrl } from '../../api/services/monster.js';
 
 function partnerArtUrl(monster) {
-  if (!monster?.cardArt?.exists || !monster.cardArt.relativePath) return null;
-  return `http://localhost:5000/api/monsters/card-art/${monster.cardArt.relativePath}`;
+  if (!monster?.cardArt?.exists) return null;
+  return getCardArtUrl(monster.cardArt.relativePath);
 }
 
 /**

--- a/frontend/src/components/evolution/EvolutionCeremonyPanel.js
+++ b/frontend/src/components/evolution/EvolutionCeremonyPanel.js
@@ -19,13 +19,9 @@ import MonsterCard from '../cards/MonsterCard.js';
 import HueBasedExplosion from '../../shared/ui/Explosion/HueBasedExplosion.js';
 import EvolutionLineage from './EvolutionLineage.js';
 import { useMonsterEvolution, EVOLUTION_STEP_LABELS } from './hooks/useMonsterEvolution.js';
+import { getCardArtUrl } from '../../api/services/monster.js';
 
 const GUIDANCE_MAX_CHARS = 200;
-
-function cardArtUrl(relativePath) {
-  if (!relativePath) return null;
-  return `http://localhost:5000/api/monsters/card-art/${relativePath}`;
-}
 
 // One "HP 100 -> 125" line for the summary strip
 function StatDelta({ label, before, after }) {
@@ -129,7 +125,7 @@ function EvolutionCeremonyPanel({ monster }) {
   }
 
   const stepLabel = EVOLUTION_STEP_LABELS[currentStep] || 'The ceremony continues';
-  const oldArt = evolution ? cardArtUrl(evolution.oldCardArtPath) : null;
+  const oldArt = evolution ? getCardArtUrl(evolution.oldCardArtPath) : null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '24px' }}>

--- a/frontend/src/components/evolution/EvolutionLineage.js
+++ b/frontend/src/components/evolution/EvolutionLineage.js
@@ -4,12 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Card, CardSection, LoadingSpinner } from '../../shared/ui/index.js';
-import { loadMonsterEvolutions } from '../../api/services/monster.js';
-
-function oldArtUrl(relativePath) {
-  if (!relativePath) return null;
-  return `http://localhost:5000/api/monsters/card-art/${relativePath}`;
-}
+import { loadMonsterEvolutions, getCardArtUrl } from '../../api/services/monster.js';
 
 /**
  * EvolutionLineage component
@@ -57,7 +52,7 @@ function EvolutionLineage({ monsterId, refreshToken }) {
         )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
           {evolutions.map((evolution) => {
-            const artUrl = oldArtUrl(evolution.oldCardArtPath);
+            const artUrl = getCardArtUrl(evolution.oldCardArtPath);
             return (
               <div
                 key={evolution.id}

--- a/frontend/src/components/settings/ImageSettingsSection.js
+++ b/frontend/src/components/settings/ImageSettingsSection.js
@@ -8,7 +8,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { Alert, Button, Input, LoadingSpinner, Select } from '../../shared/ui/index.js';
-import { API_CONFIG, API_ENDPOINTS } from '../../api/core/config.js';
+import { getCardArtUrl } from '../../api/services/monster.js';
 import * as settingsApi from '../../api/services/settings.js';
 
 function ImageSettingsSection() {
@@ -100,9 +100,7 @@ function ImageSettingsSection() {
   const modelOptions = fetchedModels.length
     ? fetchedModels
     : [model || settings.defaultModel].filter(Boolean);
-  const testImageUrl = testState.result?.imagePath
-    ? `${API_CONFIG.BASE_URL}${API_ENDPOINTS.MONSTER_CARD_ART_FILE(testState.result.imagePath)}`
-    : null;
+  const testImageUrl = getCardArtUrl(testState.result?.imagePath);
 
   return (
     <div className="llm-settings">

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,6 @@
 # never touch it) - see requirements/llm.txt for the model engine.
 Flask==3.0.0
 Flask-SQLAlchemy==3.1.1
-Flask-CORS==4.0.0
 PyMySQL==1.1.0
 cryptography>=41.0.0
 python-dotenv==1.0.0

--- a/setup/installation/basic_backend_installation.py
+++ b/setup/installation/basic_backend_installation.py
@@ -41,7 +41,6 @@ def install_basic_dependencies():
     basic_deps = [
         "Flask==3.0.0",
         "Flask-SQLAlchemy==3.1.1",
-        "Flask-CORS==4.0.0",
         "cryptography>=41.0.0",
         "PyMySQL==1.1.0",
         "python-dotenv==1.0.0",


### PR DESCRIPTION
## Why

In development the frontend hardcoded `BASE_URL: 'http://localhost:5000'`, so REST calls broke whenever the CRA dev server ran on any port other than 3000 — which is now routine, since `.claude/launch.json` enables `autoPort` so parallel Claude sessions don't collide on :3000. Off port 3000 the browser went cross-origin and the backend's CORS (`origins=['http://localhost:3000']`) rejected it: a 200 OPTIONS preflight followed by `net::ERR_FAILED` on the actual GET.

The `REACT_APP_API_URL` override only applied to production builds, so there was no dev escape hatch short of hand-editing config.

## What

Make **development same-origin** by routing everything through the CRA dev-server proxy (`frontend/package.json` already has `"proxy": "http://localhost:5000"`). `config.js` now computes `BASE_URL: ''` in dev (relative URLs) and keeps the `REACT_APP_API_URL || localhost:5000` path for production builds. Consequences, each verified:

- **SSE went relative too** (`useSSE.js`). But webpack-dev-server gzips by default and gzip buffers `text/event-stream` into silence, so `sse_routes.py` now sends `Cache-Control: no-cache, no-transform`. Measured: a browser-like `curl -H "Accept-Encoding: gzip"` for the stream **through the proxy** delivered **zero bytes** without the header and instant events with it.
- **Card-art `<img>` URLs went relative too.** `getCardArtUrl` in the monster service is now the single URL builder (it was previously dead code pointing at a nonexistent `/file/` route). The five inline `http://localhost:5000/...` copies — MonsterCard, MonsterChatPicker, EvolutionCeremonyPanel, EvolutionLineage, aiStateStore — plus `getPortraitUrl` and the settings test-image URL all delegate to it. One concept per file, per CLAUDE.md.
- **Backend CORS removed entirely.** With dev same-origin and no cross-origin production story, `flask-cors` was dead weight: dropped the `CORS(...)` call in `app.py`, the manual `Access-Control-Allow-Origin: *` on the SSE route, and `Flask-CORS` from `requirements/base.txt` + the setup installer.
- **Truthful errors** (`interceptors.js`). A dead backend behind the CRA proxy returns **500 with a plain-text `Proxy error:` body** (react-dev-utils overrides the usual 502/504). The interceptor now detects that signature and reports "Backend unreachable," and the generic network-error message no longer claims requests go to `localhost:5000` directly.
- Housekeeping: stale `STREAMING_EVENTS` catalog entry (pointing at a removed route) is now `SSE_EVENTS: '/api/sse/events'`; `docs/api/README.md` documents the proxy policy; `.claude/launch.json` gains `autoPort: true` (it previously only existed on an unmerged branch).

## Verification

Ran the frontend via `.claude/launch.json` on a **non-3000 port** (CRA picked 62693) against the full backend stack. Clicked through title → Continue → home base → Developer (Overview + API Tests). Network tab: `game-state`, `following`, `party`, `player`, `sse/events`, both card-art images (relative `src`, pixels loaded), `game_tester/tests`, `generation/logs` + `log-options` — **all 200, zero failures**. Suites: **pytest 17/17** offline suites, **jest 24/24**, plus prettier, ruff, and the 500-line size check all green.

## Reviewer notes

- The permissive `Access-Control-Allow-*` headers you may still see on dev responses come from **webpack-dev-server itself**, not the backend — the backend now sends none.
- Pre-existing console "Maximum update depth" noise on the Developer screen is the separate known bug fixed in open PR #173, not touched here.
- A few leftover unused-import build warnings (unrelated to this change) are tracked separately for cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)