### PR TITLE
Clean up after the dev-proxy migration: dead endpoint + prod-CORS note

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -21,6 +21,11 @@ links to the per-domain files.
   the CRA dev server's proxy (`frontend/package.json` `"proxy"`) forwards
   them to `:5000`. Everything stays same-origin on any dev-server port, so
   the backend serves no CORS headers.
+- Production: the frontend uses `REACT_APP_API_URL` (baked in at build
+  time). Because the backend no longer ships CORS headers, a production
+  deploy that puts the API on a **different origin** than the frontend
+  would be blocked by the browser — serve both from the same origin
+  (reverse proxy), or re-add cross-origin headers for that API host.
 
 ## Standard response format
 Every JSON endpoint returns an envelope:

--- a/frontend/src/api/core/config.js
+++ b/frontend/src/api/core/config.js
@@ -44,7 +44,6 @@ export const API_ENDPOINTS = {
   // Monster card art
   MONSTER_GENERATE_CARD_ART: (id) => `/api/monsters/${id}/card-art`,
   MONSTER_GET_CARD_ART: (id) => `/api/monsters/${id}/card-art`,
-  MONSTER_CARD_ART_FILE: (path) => `/api/monsters/card-art/${path}`,
 
   // ===== GAME STATE MANAGEMENT =====
   GAME_STATE: '/api/game-state',


### PR DESCRIPTION
## What

Two small loose ends left over from #175 (dev API uses relative URLs through the CRA proxy):

- **Remove the dead `MONSTER_CARD_ART_FILE` endpoint const** from `frontend/src/api/core/config.js`. Its last consumer (`ImageSettingsSection`) switched to `getCardArtUrl` in #175, leaving the const with zero references.
- **Document the production consequence of dropping Flask-CORS** in `docs/api/README.md`. Development is same-origin through the CRA proxy, but a production deploy that puts the API on a *different origin* than the frontend would now be blocked by the browser — the note tells a future deployer to serve same-origin (reverse proxy) or re-add cross-origin headers.

## Why

These surfaced while reviewing everything merged after #169. Neither is a bug in shipped behavior — #175 works correctly in dev — but the dead const is clutter and the CORS trade-off was invisible (only mentioned in the #175 commit's dev reasoning, not in any doc a deployer would read).

## Reviewer notes

- No runtime surface: one is a dead-code deletion, the other is docs. Nothing browser-observable to verify.
- Confirmed green locally: prettier ✅, eslint ✅ (config.js), and `MONSTER_CARD_ART_FILE` has no remaining references anywhere in `frontend/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)