### PR TITLE
Fix frontend startup crash: detect interrupted npm installs

### DIFF
--- a/setup/checks/nodejs_checks.py
+++ b/setup/checks/nodejs_checks.py
@@ -55,8 +55,14 @@ def check_frontend_dependencies():
     if not frontend_path.exists():
         return False, "Frontend directory not found"
 
-    if node_modules_path.exists():
+    # Probe for react-scripts (what "npm start" runs), not the bare folder:
+    # npm creates node_modules immediately and fills it afterward, so an
+    # interrupted install leaves an empty node_modules that would pass an
+    # existence check forever while the frontend dies on startup.
+    if (node_modules_path / "react-scripts").exists():
         return True, "Frontend dependencies installed"
+    elif node_modules_path.exists():
+        return False, "Frontend dependencies incomplete (interrupted install?)"
     else:
         return False, "Frontend dependencies not installed"
 

--- a/setup/installation/nodejs_installation.py
+++ b/setup/installation/nodejs_installation.py
@@ -16,9 +16,12 @@ def install_frontend_dependencies():
     if not frontend_path.exists():
         return False, "Frontend directory not found"
 
-    # Check if already installed
+    # "Already installed" means react-scripts is actually present, not just
+    # that node_modules exists: npm creates the folder before filling it, so
+    # an interrupted install leaves an empty node_modules. Re-running
+    # "npm install" into a partial node_modules is safe - npm fills the gaps.
     node_modules_path = frontend_path / "node_modules"
-    if node_modules_path.exists():
+    if (node_modules_path / "react-scripts").exists():
         return True, "Frontend dependencies already installed"
 
     # Find npm executable
@@ -29,6 +32,6 @@ def install_frontend_dependencies():
 
     try:
         subprocess.run([npm_path, "install"], cwd=str(frontend_path), check=True)
-        return True, "npm intalled"
+        return True, "Frontend dependencies installed"
     except subprocess.CalledProcessError as e:
         return False, f"npm install failed: {e}"

--- a/start_frontend.bat
+++ b/start_frontend.bat
@@ -17,8 +17,11 @@ if errorlevel 1 (
     exit /b 1
 )
 
-REM Check if node_modules exists
-if not exist "frontend\node_modules" (
+REM Check for react-scripts specifically, not just the node_modules folder:
+REM npm creates node_modules first and fills it afterward, so an interrupted
+REM install leaves an empty folder that would skip this install forever and
+REM make "npm start" die with "react-scripts is not recognized"
+if not exist "frontend\node_modules\react-scripts" (
     echo Frontend dependencies not installed
     echo.
     echo Installing React dependencies...


### PR DESCRIPTION
## Summary
- The frontend crashed immediately on start (`'react-scripts' is not recognized`) because `frontend/node_modules` existed but was empty — the leftover of a previously interrupted `npm install`.
- Every dependency check in the repo (`start_frontend.bat`, `setup/checks/nodejs_checks.py`, `setup/installation/nodejs_installation.py`) only tested that the `node_modules` folder *exists*, not that it's populated, so the install step was silently skipped and the setup walkthrough falsely reported dependencies as installed.
- All three checks now probe for `node_modules/react-scripts` (the package `npm start` actually needs) instead of the bare folder, so a partial `node_modules` triggers a re-install rather than a crash.
- Also fixed a stray "npm intalled" typo in the installer's success message.

## Test plan
- [x] Ran `npm install` in `frontend/` to repair the local empty `node_modules`, then started the dev server via the preview tool — title screen renders with no console errors (only expected `/api/*` failures since the backend wasn't running).
- [x] Simulated an interrupted install (empty `node_modules` folder) and confirmed `check_frontend_dependencies()` now reports "Frontend dependencies incomplete (interrupted install?)" instead of "installed".
- [x] `ruff check backend setup tools` — clean.
- [x] `pytest` — 18/18 offline suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)