### PR TITLE
Congruence tripwires: make the hand-maintained mirrors fail loudly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,15 +8,22 @@ when he wants detail.
 
 ## Read these before big changes
 
+- [docs/README.md](docs/README.md) — **the docs map.** Six categories with
+  opposite maintenance rules; only eleven files are binding. Read this
+  before trusting or updating anything in `docs/`.
 - [docs/architecture.md](docs/architecture.md) — layers, the async
   workflow/SSE model, the referee philosophy. **The step-name contract
   matters:** frontend event hooks key off workflow `on_update` step
-  strings — renaming one is a breaking change.
+  strings — renaming one is a breaking change, and
+  `tests/test_step_contract.py` will fail if you do.
 - [docs/tuning.md](docs/tuning.md) — every gameplay knob and where it lives.
 - [docs/api/README.md](docs/api/README.md) — HTTP surface; async endpoints
-  return `{ workflow_id }` and results arrive over SSE.
+  return `{ workflow_id }` and results arrive over SSE. The event catalog
+  is asserted against the registry by `tests/test_event_parity.py`.
 - [docs/plans/](docs/plans/) — one plan doc per initiative, kept current
-  (status, deviations). `docs/design/` is the historical design phase.
+  (status, deviations). `docs/design/` is *mixed*: the Feb 2025
+  deliverables and the retrospective are frozen history; the engine
+  musings and the wish engine are unbuilt proposals.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,14 @@ when he wants detail.
   (status, deviations). `docs/design/` is *mixed*: the Feb 2025
   deliverables and the retrospective are frozen history; the engine
   musings and the wish engine are unbuilt proposals.
+- **Directory contracts.** Four subtrees carry their own `CLAUDE.md` with
+  the rules for working there — the ones no suite can enforce:
+  [backend/game/](backend/game/CLAUDE.md),
+  [backend/tests/](backend/tests/CLAUDE.md),
+  [frontend/src/shared/](frontend/src/shared/CLAUDE.md),
+  [frontend/src/components/](frontend/src/components/CLAUDE.md).
+  Read the nearest one before editing in its subtree; this file holds the
+  repo-wide rules and they hold the local ones.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,11 +57,19 @@ test DB (`DB_NAME_TEST`, auto-created via `backend/tests/harness.py`) —
 safe to run anytime. MySQL must be running; nothing else is (no local
 model, no image service — generation is cloud-API-first).
 
-**Before pushing, run all six checks above** (lint, format, file sizes,
-pytest, prettier, jest). Those six *are* CI — `.github/workflows/ci.yml`
-runs exactly them, so a green local run means a green PR. `ruff check`
-and `ruff format --check` are different tools; passing one says nothing
-about the other.
+**Before pushing, run all six checks** (lint, format, file sizes, pytest,
+prettier, jest) — or just run them in one go:
+
+```bash
+./venv/Scripts/python.exe tools/check_all.py           # all six, ~10s
+./venv/Scripts/python.exe tools/check_all.py backend   # skip the npm ones
+```
+
+(`check_all.bat` does the same from Explorer.) Those six *are* CI —
+`.github/workflows/ci.yml` runs exactly them, so a green local run means
+a green PR. Add any new workflow step to `tools/check_all.py` too. Note
+that `ruff check` and `ruff format --check` are different tools: passing
+one says nothing about the other.
 
 ## The hard rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,12 +40,13 @@ when he wants detail.
 ./venv/Scripts/python.exe backend/run.py            # start on :5000
 PYTHONIOENCODING=utf-8 ./venv/Scripts/python.exe -m backend.tests.test_evolution   # one suite
 ./venv/Scripts/python.exe -m pytest                 # all offline suites
-./venv/Scripts/python.exe -m ruff check backend setup tools   # lint
+./venv/Scripts/python.exe -m ruff check backend setup tools          # lint
+./venv/Scripts/python.exe -m ruff format --check backend setup tools # format
 ./venv/Scripts/python.exe tools/check_file_sizes.py # 500-line ceiling
 
 # Frontend (from frontend/)
 npm start          # dev server on :3000
-npm test           # jest
+npm test -- --watchAll=false   # jest, the way CI runs it
 npx prettier --check src
 
 # Or start_game.bat / start_backend.bat / start_frontend.bat from Explorer
@@ -55,6 +56,12 @@ Offline suites stub the LLM and the image API, and use the dedicated
 test DB (`DB_NAME_TEST`, auto-created via `backend/tests/harness.py`) —
 safe to run anytime. MySQL must be running; nothing else is (no local
 model, no image service — generation is cloud-API-first).
+
+**Before pushing, run all six checks above** (lint, format, file sizes,
+pytest, prettier, jest). Those six *are* CI — `.github/workflows/ci.yml`
+runs exactly them, so a green local run means a green PR. `ruff check`
+and `ruff format --check` are different tools; passing one says nothing
+about the other.
 
 ## The hard rules
 

--- a/backend/game/CLAUDE.md
+++ b/backend/game/CLAUDE.md
@@ -1,0 +1,62 @@
+# backend/game/ — the game itself
+
+Rules for working in this directory. Repo-wide rules (layering, the
+gateway, the 500-line ceiling, word ladders) are in the root `CLAUDE.md`
+and are not repeated here. The narrative explanation of *why* the layers
+exist is [docs/architecture.md](../../docs/architecture.md).
+
+## The domains
+
+Nine, each owning one part of the game:
+
+`battle` · `chat` · `dungeon` · `inventory` · `memory` · `monster` ·
+`player` · `state` · `utils`
+
+`state/` owns the world itself (new game, global state) and `utils/` is
+shared machinery (context budgets, prompt helpers, rolling summaries) —
+neither is a gameplay domain.
+
+## File roles inside a domain
+
+Every file name means something. Match the convention rather than
+inventing a new shape:
+
+- `manager.py` — owns the domain's state. Every domain has one.
+  Persistent run state usually lives in the `global_variables` table
+  (`dungeon_state`, `battle_state`), not in module globals.
+- `generator.py` — composes prompts and calls the AI gateway. This is the
+  only kind of file in a domain that talks to the LLM.
+- `registered_workflows.py` — the async entry points. **Keep these thin:
+  validate, delegate, return.** When logic outgrows the file it moves to
+  a sibling package (`dungeon/handlers/`, `battle/turn/`), not into the
+  workflow.
+- `constants.py` — the word ladders and enums the LLM chooses among.
+- Anything else is a named domain concern (`affinity.py`, `goal.py`,
+  `spoils.py`, `evolution_eligibility.py`). One concept per file.
+
+## Contracts that reach outside this directory
+
+Both are enforced — breaking them fails a suite, not a review:
+
+- **Step names.** Workflow `on_update` strings are a frontend contract.
+  Renaming one breaks `tests/test_step_contract.py`. Steps come either
+  from a local `step` variable or the shared `WorkflowStep` pointer
+  (`core/workflow_steps.py`) when a workflow spans handler modules.
+- **Events.** Declared in `core/events/<domain>_events.py`. A new event
+  with `send_to_frontend: True` needs a frontend handler and a line in
+  `docs/api/events-and-sse.md` in the same change, or
+  `tests/test_event_parity.py` fails.
+
+## Adding a domain
+
+Register its workflows by importing the package in `game/__init__.py` —
+`@register_workflow` validates signatures at import time, so a domain
+that is never imported silently has no workflows.
+
+## Verification
+
+```bash
+./venv/Scripts/python.exe -m ruff check backend
+PYTHONIOENCODING=utf-8 ./venv/Scripts/python.exe -m pytest
+./venv/Scripts/python.exe tools/check_file_sizes.py
+```

--- a/backend/tests/CLAUDE.md
+++ b/backend/tests/CLAUDE.md
@@ -1,0 +1,50 @@
+# backend/tests/ — offline suites and dev utilities
+
+Rules for working in this directory. Repo-wide rules are in the root
+`CLAUDE.md`.
+
+## Two kinds of file live here
+
+- **Suites** (`test_*.py`) — readable scripts of `check(...)` assertions.
+- **Dev utilities** (`add_*.py`, `reset_db.py`, `clear_following.py`,
+  `random_location.py`, `generate_monster_profiles.py`) — one-off scripts
+  run by hand. They are not suites and must not be registered as such.
+
+## Suite shape
+
+Copy an existing suite rather than inventing a shape. Every suite has:
+
+- module-level `PASSED` / `FAILED` counters and a
+  `check(name, condition, detail='')` helper that prints ✅ / ❌
+- a `main()` that runs the checks, prints a summary, and **returns the
+  failure count** (not a bool, not None)
+- `if __name__ == '__main__': raise SystemExit(main())`
+- a header comment ending in the standalone usage line
+
+## Register it or pytest will not see it
+
+`pyproject.toml` sets `python_files = ["test_offline_suites.py"]` —
+pytest collects **only** the bridge file. A new suite must be added to
+its `SUITES` list or it will pass silently by never running.
+
+## Offline means offline
+
+Suites run with the LLM stubbed, the image API stubbed, and the dedicated
+test database (`DB_NAME_TEST`, built by `harness.py`). No network, no
+local model, no image service. A test that needs a running game does not
+belong here.
+
+Two suites need no database at all — `test_event_parity.py` and
+`test_step_contract.py` read source files and compare sets. When adding
+that kind of tripwire, give it a scanner guard (a floor on how much it
+expects to find) so a refactor makes it fail loudly instead of passing
+vacuously on zero matches.
+
+## Verification
+
+```bash
+PYTHONIOENCODING=utf-8 ./venv/Scripts/python.exe -m backend.tests.<suite>   # one suite
+PYTHONIOENCODING=utf-8 ./venv/Scripts/python.exe -m pytest                  # all of them
+```
+
+MySQL must be running for any suite that touches the database.

--- a/backend/tests/test_event_parity.py
+++ b/backend/tests/test_event_parity.py
@@ -22,7 +22,9 @@ FAILED = 0
 # behaves the same from pytest, the command line, and the Developer screen
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HANDLER_DIR = REPO_ROOT / 'frontend' / 'src' / 'api' / 'events'
-EVENT_PROVIDER = REPO_ROOT / 'frontend' / 'src' / 'app' / 'contexts' / 'EventContext' / 'EventProvider.js'
+EVENT_PROVIDER = (
+    REPO_ROOT / 'frontend' / 'src' / 'app' / 'contexts' / 'EventContext' / 'EventProvider.js'
+)
 EVENT_CATALOG_DOC = REPO_ROOT / 'docs' / 'api' / 'events-and-sse.md'
 
 # An event name is always dotted and lower-case ('monster.art_ready',
@@ -83,7 +85,11 @@ def main():
     check('backend registry declares SSE events', bool(sse_events), 'registry came back empty')
     check('frontend handler files found', bool(handlers_by_file), f'looked in {HANDLER_DIR}')
     check('EventProvider is where we expect it', EVENT_PROVIDER.exists(), str(EVENT_PROVIDER))
-    check('event catalog doc is where we expect it', EVENT_CATALOG_DOC.exists(), str(EVENT_CATALOG_DOC))
+    check(
+        'event catalog doc is where we expect it',
+        EVENT_CATALOG_DOC.exists(),
+        str(EVENT_CATALOG_DOC),
+    )
 
     # ===== Backend declares it -> frontend handles it =====
     # This is the drift that ships silently: the backend announces something

--- a/backend/tests/test_event_parity.py
+++ b/backend/tests/test_event_parity.py
@@ -1,0 +1,163 @@
+# Event Parity Tests - OFFLINE (pure logic, no LLM, no DB, no subprocesses)
+# The SSE event contract is mirrored by hand in four places: the backend
+# registry declares an event, a frontend handler file consumes it, the
+# EventProvider spreads that handler file into the live SSE map, and
+# docs/api/events-and-sse.md documents it for anyone working the frontend.
+# Nothing connected those four, so they could - and did - drift apart
+# silently (monster.affinity_changed shipped with no frontend handler).
+#
+# This suite is the tripwire. It reads all four sources and fails the
+# moment any of them stops agreeing with the registry, which is the
+# single source of truth for what the backend can emit.
+#
+# Usage: python -m backend.tests.test_event_parity   (from project root)
+
+import re
+from pathlib import Path
+
+PASSED = 0
+FAILED = 0
+
+# Resolved from this file rather than the working directory so the suite
+# behaves the same from pytest, the command line, and the Developer screen
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HANDLER_DIR = REPO_ROOT / 'frontend' / 'src' / 'api' / 'events'
+EVENT_PROVIDER = REPO_ROOT / 'frontend' / 'src' / 'app' / 'contexts' / 'EventContext' / 'EventProvider.js'
+EVENT_CATALOG_DOC = REPO_ROOT / 'docs' / 'api' / 'events-and-sse.md'
+
+# An event name is always dotted and lower-case ('monster.art_ready',
+# 'llm.generation.started'). Requiring the dot keeps these patterns from
+# matching the camelCase broadcast names that live alongside them.
+EVENT_NAME = r"[a-z_]+(?:\.[a-z_]+)+"
+
+# Handler files register events as quoted object keys: 'monster.created': (eventData) => {
+HANDLER_KEY_PATTERN = re.compile(rf"^\s*'({EVENT_NAME})'\s*:", re.MULTILINE)
+
+# EventProvider builds the live SSE map by spreading each handler export: ...monsterEventHandlers,
+HANDLER_SPREAD_PATTERN = re.compile(r"\.\.\.([A-Za-z]+EventHandlers)\b")
+
+# The doc's catalog entries are bullets that lead with the event name in
+# backticks. Anchoring to the line start skips prose mentions of events.
+DOC_EVENT_PATTERN = re.compile(rf"^-\s+`({EVENT_NAME})`", re.MULTILINE)
+
+
+def check(name: str, condition: bool, detail: str = ''):
+    global PASSED, FAILED
+    if condition:
+        PASSED += 1
+        print(f"  ✅ {name}")
+    else:
+        FAILED += 1
+        print(f"  ❌ {name}{f' - {detail}' if detail else ''}")
+
+
+def describe(events) -> str:
+    """Render a set of event names for a failure message, newest problem first"""
+    return ', '.join(sorted(events)) if events else '(none)'
+
+
+def read_frontend_handlers() -> dict:
+    """Map each *EventHandlers.js file stem to the event names it handles"""
+    handlers_by_file = {}
+    for handler_file in sorted(HANDLER_DIR.glob('*EventHandlers.js')):
+        source = handler_file.read_text(encoding='utf-8')
+        handlers_by_file[handler_file.stem] = set(HANDLER_KEY_PATTERN.findall(source))
+    return handlers_by_file
+
+
+def main():
+    # Importing the events package runs every *_events.py module, which is
+    # what populates EVENT_REGISTRY - no app context or database needed
+    from backend.core.events import get_internal_events, get_sse_events
+
+    print('🧪 EVENT PARITY TESTS')
+    print('=' * 50)
+
+    sse_events = set(get_sse_events())
+    internal_events = set(get_internal_events())
+    handlers_by_file = read_frontend_handlers()
+    handled_events = set().union(*handlers_by_file.values()) if handlers_by_file else set()
+
+    # ===== The sources are readable at all =====
+    print('\n-- sources --')
+    check('backend registry declares SSE events', bool(sse_events), 'registry came back empty')
+    check('frontend handler files found', bool(handlers_by_file), f'looked in {HANDLER_DIR}')
+    check('EventProvider is where we expect it', EVENT_PROVIDER.exists(), str(EVENT_PROVIDER))
+    check('event catalog doc is where we expect it', EVENT_CATALOG_DOC.exists(), str(EVENT_CATALOG_DOC))
+
+    # ===== Backend declares it -> frontend handles it =====
+    # This is the drift that ships silently: the backend announces something
+    # over SSE and nothing on the other end is listening, so the UI quietly
+    # shows stale state until an unrelated refetch happens to fix it.
+    print('\n-- backend -> frontend --')
+    unhandled = sse_events - handled_events
+    check(
+        'every send_to_frontend event has a handler',
+        not unhandled,
+        f'declared but never handled: {describe(unhandled)}',
+    )
+
+    # The reverse: a handler for an event the backend cannot emit is dead
+    # code, and usually means an event was renamed or removed on one side.
+    orphaned = handled_events - sse_events - internal_events
+    check(
+        'every handler maps to a registered event',
+        not orphaned,
+        f'handled but never declared: {describe(orphaned)}',
+    )
+
+    # Internal events deliberately never reach SSE, so a handler for one
+    # would wait forever for a message that is not coming.
+    listening_to_internal = handled_events & internal_events
+    check(
+        'no handler listens for an internal-only event',
+        not listening_to_internal,
+        f'internal events with handlers: {describe(listening_to_internal)}',
+    )
+
+    # ===== Handler files -> the live SSE map =====
+    # A handler file that nobody spreads into EventProvider is inert: every
+    # event in it is effectively unhandled no matter how correct it looks.
+    print('\n-- handler files -> EventProvider --')
+    provider_source = EVENT_PROVIDER.read_text(encoding='utf-8')
+    spread_handlers = set(HANDLER_SPREAD_PATTERN.findall(provider_source))
+    unwired = set(handlers_by_file) - spread_handlers
+    check(
+        'every handler file is spread into EventProvider',
+        not unwired,
+        f'file exists but is never wired up: {describe(unwired)}',
+    )
+    missing_files = spread_handlers - set(handlers_by_file)
+    check(
+        'every spread handler has a handler file',
+        not missing_files,
+        f'spread but no matching file: {describe(missing_files)}',
+    )
+
+    # ===== The documented catalog -> the registry =====
+    # docs/api/events-and-sse.md is the reference a frontend developer reads
+    # instead of the backend source. It is only worth reading if it cannot
+    # quietly fall behind, so it is checked like code.
+    print('\n-- documented catalog -> registry --')
+    doc_source = EVENT_CATALOG_DOC.read_text(encoding='utf-8')
+    documented_events = set(DOC_EVENT_PATTERN.findall(doc_source))
+    undocumented = sse_events - documented_events
+    check(
+        'every SSE event appears in the catalog',
+        not undocumented,
+        f'emitted but undocumented: {describe(undocumented)}',
+    )
+    invented = documented_events - sse_events - internal_events
+    check(
+        'the catalog documents no event that does not exist',
+        not invented,
+        f'documented but never declared: {describe(invented)}',
+    )
+
+    print('\n' + '=' * 50)
+    print(f'🎉 {PASSED} passed, {FAILED} failed')
+    return FAILED
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/tests/test_offline_suites.py
+++ b/backend/tests/test_offline_suites.py
@@ -28,6 +28,7 @@ SUITES = [
     'test_deepseek_provider',
     'test_gemini_provider',
     'test_setup_registry',
+    'test_event_parity',
 ]
 
 

--- a/backend/tests/test_offline_suites.py
+++ b/backend/tests/test_offline_suites.py
@@ -29,6 +29,7 @@ SUITES = [
     'test_gemini_provider',
     'test_setup_registry',
     'test_event_parity',
+    'test_step_contract',
 ]
 
 

--- a/backend/tests/test_step_contract.py
+++ b/backend/tests/test_step_contract.py
@@ -1,0 +1,163 @@
+# Step Contract Tests - OFFLINE (pure logic, no LLM, no DB, no subprocesses)
+# Workflow on_update step names are the contract docs/architecture.md warns
+# is breaking-if-renamed: the frontend keys progress labels and branching
+# logic off them. They are also the least protected thing in the repo -
+# bare string literals on both sides, sometimes in a different domain
+# folder than the workflow that emits them (the player creation forge
+# reads steps emitted by game/player, the evolution ceremony by game/monster).
+#
+# The contract is one-directional. A backend step no one displays is
+# ordinary - most steps are just progress pings. A frontend reference to a
+# step the backend cannot emit is the bug: the label silently never fires.
+# This suite asserts that direction, so renaming a step on the backend
+# fails here instead of quietly blanking a screen.
+#
+# Usage: python -m backend.tests.test_step_contract   (from project root)
+
+import re
+from pathlib import Path
+
+PASSED = 0
+FAILED = 0
+
+# Resolved from this file rather than the working directory so the suite
+# behaves the same from pytest, the command line, and the Developer screen
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / 'backend'
+FRONTEND_DIR = REPO_ROOT / 'frontend' / 'src'
+WORKFLOW_STEP_MODULE = BACKEND_DIR / 'core' / 'workflow_steps.py'
+
+# Backend emits steps two ways. The older workflows keep a local `step`
+# variable and pass it to on_update; workflows split across handler modules
+# share a WorkflowStep pointer and call step.emit / .mark / .emit_event.
+LOCAL_STEP_PATTERN = re.compile(r"""\bstep\s*=\s*['"]([a-z_]+)['"]""")
+STEP_POINTER_PATTERN = re.compile(r"""\bstep\.(?:emit|mark|emit_event)\(\s*['"]([a-z_]+)['"]""")
+# WorkflowStep's constructor seeds the pointer before any step is emitted
+STEP_DEFAULT_PATTERN = re.compile(r"""self\.name\s*=\s*['"]([a-z_]+)['"]""")
+
+# Frontend references steps two ways: label maps keyed by step name, and
+# inline comparisons in the event hooks.
+STEP_LABEL_MAP_PATTERN = re.compile(
+    r"""[A-Z_]*STEP_LABELS\s*=\s*\{(.*?)\}""", re.DOTALL
+)
+STEP_LABEL_KEY_PATTERN = re.compile(r"""^\s*([a-z_]+)\s*:""", re.MULTILINE)
+STEP_COMPARISON_PATTERN = re.compile(r"""\bstep\s*(?:===|!==)\s*['"]([a-z_]+)['"]""")
+
+# Guards against a scanner that silently stops matching: if a refactor
+# changes how steps are written, the suite must fail loudly rather than
+# pass vacuously forever. These floors are well under today's counts.
+MINIMUM_BACKEND_STEPS = 40
+MINIMUM_LABEL_MAPS = 2
+
+
+def check(name: str, condition: bool, detail: str = ''):
+    global PASSED, FAILED
+    if condition:
+        PASSED += 1
+        print(f"  ✅ {name}")
+    else:
+        FAILED += 1
+        print(f"  ❌ {name}{f' - {detail}' if detail else ''}")
+
+
+def describe(steps) -> str:
+    """Render a set of step names for a failure message"""
+    return ', '.join(sorted(steps)) if steps else '(none)'
+
+
+def python_sources():
+    for path in sorted(BACKEND_DIR.rglob('*.py')):
+        if '__pycache__' in path.parts:
+            continue
+        yield path
+
+
+def javascript_sources():
+    yield from sorted(FRONTEND_DIR.rglob('*.js'))
+
+
+def collect_emitted_steps() -> set:
+    """Every step name the backend can report through on_update"""
+    emitted = set()
+    for path in python_sources():
+        source = path.read_text(encoding='utf-8')
+        emitted.update(LOCAL_STEP_PATTERN.findall(source))
+        emitted.update(STEP_POINTER_PATTERN.findall(source))
+        if path == WORKFLOW_STEP_MODULE:
+            emitted.update(STEP_DEFAULT_PATTERN.findall(source))
+    return emitted
+
+
+def collect_referenced_steps() -> tuple:
+    """Every step name the frontend keys off, and the label maps it found"""
+    referenced = {}
+    label_maps_found = 0
+    for path in javascript_sources():
+        source = path.read_text(encoding='utf-8')
+        where = path.relative_to(REPO_ROOT).as_posix()
+
+        for map_body in STEP_LABEL_MAP_PATTERN.findall(source):
+            label_maps_found += 1
+            for step_name in STEP_LABEL_KEY_PATTERN.findall(map_body):
+                referenced.setdefault(step_name, where)
+
+        for step_name in STEP_COMPARISON_PATTERN.findall(source):
+            referenced.setdefault(step_name, where)
+
+    return referenced, label_maps_found
+
+
+def main():
+    print('🧪 STEP CONTRACT TESTS')
+    print('=' * 50)
+
+    emitted_steps = collect_emitted_steps()
+    referenced_steps, label_maps_found = collect_referenced_steps()
+
+    # ===== The scanners still work =====
+    # A tripwire that quietly stops finding anything is worse than none
+    print('\n-- scanners --')
+    check(
+        'backend step scan finds the workflow steps',
+        len(emitted_steps) >= MINIMUM_BACKEND_STEPS,
+        f'found {len(emitted_steps)}, expected at least {MINIMUM_BACKEND_STEPS} - '
+        'has the emission style changed?',
+    )
+    check(
+        'frontend scan finds the step label maps',
+        label_maps_found >= MINIMUM_LABEL_MAPS,
+        f'found {label_maps_found} *_STEP_LABELS maps, expected at least {MINIMUM_LABEL_MAPS}',
+    )
+    check(
+        'frontend scan finds step references',
+        bool(referenced_steps),
+        'no step names referenced anywhere in frontend/src',
+    )
+
+    # ===== The contract itself =====
+    # Every step the frontend keys off must be one the backend can emit.
+    # A reference to a step that no longer exists never fires: the label
+    # stays blank, or the branch never runs, and nothing errors.
+    print('\n-- frontend -> backend --')
+    dangling = {step: where for step, where in referenced_steps.items() if step not in emitted_steps}
+    check(
+        'every referenced step is one the backend emits',
+        not dangling,
+        'referenced but never emitted: '
+        + ', '.join(f'{step} ({where})' for step, where in sorted(dangling.items())),
+    )
+
+    # Context, not a rule: most steps are progress pings with no label.
+    unreferenced = emitted_steps - set(referenced_steps)
+    print(
+        f'\n  ℹ️  {len(referenced_steps)} of {len(emitted_steps)} steps are referenced by the '
+        f'frontend; {len(unreferenced)} are backend-only progress pings'
+    )
+
+    print('\n' + '=' * 50)
+    print(f'🎉 {PASSED} passed, {FAILED} failed')
+    return FAILED
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/backend/tests/test_step_contract.py
+++ b/backend/tests/test_step_contract.py
@@ -37,9 +37,7 @@ STEP_DEFAULT_PATTERN = re.compile(r"""self\.name\s*=\s*['"]([a-z_]+)['"]""")
 
 # Frontend references steps two ways: label maps keyed by step name, and
 # inline comparisons in the event hooks.
-STEP_LABEL_MAP_PATTERN = re.compile(
-    r"""[A-Z_]*STEP_LABELS\s*=\s*\{(.*?)\}""", re.DOTALL
-)
+STEP_LABEL_MAP_PATTERN = re.compile(r"""[A-Z_]*STEP_LABELS\s*=\s*\{(.*?)\}""", re.DOTALL)
 STEP_LABEL_KEY_PATTERN = re.compile(r"""^\s*([a-z_]+)\s*:""", re.MULTILINE)
 STEP_COMPARISON_PATTERN = re.compile(r"""\bstep\s*(?:===|!==)\s*['"]([a-z_]+)['"]""")
 
@@ -139,7 +137,9 @@ def main():
     # A reference to a step that no longer exists never fires: the label
     # stays blank, or the branch never runs, and nothing errors.
     print('\n-- frontend -> backend --')
-    dangling = {step: where for step, where in referenced_steps.items() if step not in emitted_steps}
+    dangling = {
+        step: where for step, where in referenced_steps.items() if step not in emitted_steps
+    }
     check(
         'every referenced step is one the backend emits',
         not dangling,

--- a/check_all.bat
+++ b/check_all.bat
@@ -1,0 +1,39 @@
+@echo off
+title Monster Hunter Game - Pre-Push Checks
+
+echo.
+echo ================================================================
+echo            Monster Hunter Game - Pre-Push Checks
+echo ================================================================
+echo.
+echo Runs the same six checks GitHub runs on a pull request.
+echo All green here means a green PR.
+echo.
+
+REM The venv is created by the setup that start_game.bat runs - judge
+REM by the interpreter inside it, not the folder
+if not exist "venv\Scripts\python.exe" (
+    echo The game's Python environment is not set up yet.
+    echo Run start_game.bat first - it sets everything up for you.
+    pause
+    exit /b 1
+)
+
+REM MySQL must be running for the offline suites to connect
+venv\Scripts\python.exe tools\check_all.py
+set CHECK_RESULT=%ERRORLEVEL%
+
+echo.
+if %CHECK_RESULT% NEQ 0 (
+    echo ================================================================
+    echo  Something needs fixing before you push. Details are above.
+    echo ================================================================
+) else (
+    echo ================================================================
+    echo  Everything passed - safe to push.
+    echo ================================================================
+)
+
+echo.
+pause
+exit /b %CHECK_RESULT%

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,104 @@
+# The docs map
+
+This folder holds six kinds of document with different audiences and
+opposite maintenance rules. Without that distinction everything reads as
+equally binding, which makes the whole folder feel perpetually out of
+date — so before reading or updating anything here, find its category.
+
+**Only the first category owns you.** Eleven of the 44 files in `docs/`
+have to be true (plus root `CLAUDE.md`). The rest are records, plans, or
+daydreams, and several would be damaged by being brought "up to date".
+
+---
+
+## 1. Binding — must be true
+
+The working contract. If the code contradicts one of these, the doc is a
+bug: fix it in the same commit.
+
+| Doc | Covers |
+| --- | --- |
+| [architecture.md](architecture.md) | Layers, the async workflow/SSE model, the referee philosophy, context budgets, the directory map |
+| [tuning.md](tuning.md) | Every gameplay knob, where it lives, its default |
+| [api/](api/) (9 files) | The HTTP surface, as a reference for working the frontend without reading backend code |
+| `CLAUDE.md` (repo root) | Conventions, commands, the hard rules |
+
+**Parts of this category are enforced, not trusted.**
+`backend/tests/test_event_parity.py` asserts that the event catalog in
+[api/events-and-sse.md](api/events-and-sse.md) matches the backend
+registry exactly, and `test_step_contract.py` guards the step-name
+contract. Those cannot silently fall behind. The prose around them still
+can — see [plans/congruence-tripwires.md](plans/congruence-tripwires.md).
+
+## 2. Work orders — the current queue
+
+Deliberately diary-like: they carry a status line, log deviations as they
+happen, and stay after shipping as the record of what was decided and
+why. **Do not tidy the history out of them.**
+
+- [plans/](plans/) — one doc per initiative, 13 of them. Every file states
+  `**Status:**` at the top: IMPLEMENTED (10), PLANNED (2 —
+  `codebase-health`, `monster-requests`), IN PROGRESS (1 —
+  `congruence-tripwires`). The status line is the thing to keep truthful.
+- [bug-hunt.md](bug-hunt.md) — verified bugs and cleared hypotheses from a
+  line-level correctness read
+- [prompt-review.md](prompt-review.md) — per-template critique of
+  `backend/ai/llm/prompts/`
+
+Check these before starting a new initiative; they are written to be
+picked up and executed.
+
+## 3. Aspirational — what might be
+
+Congruent with nothing. There is no such thing as one of these being out
+of date, and no maintenance is owed. Update only when you change your mind.
+
+- [roadmap.md](roadmap.md) — ranked gameplay direction (Requests →
+  Nemesis → Bonds → Regions)
+- [ideas.md](ideas.md) — unranked by effort, ranked by heart
+- [design/wish-engine.md](design/wish-engine.md) — design-only proposal,
+  no code written
+- [design/imagination-engine/](design/imagination-engine/) and
+  [design/setting-engine/](design/setting-engine/) — exploratory musings,
+  self-labelled as not plan docs
+
+## 4. Historical — must NOT be updated
+
+Records of what was thought at the time. Correcting them destroys the
+thing they are for.
+
+- [design/gameplay_design.md](design/gameplay_design.md) and
+  [design/story_design.md](design/story_design.md) — Feb 2025 design-phase
+  deliverables from the original Waterfall SDLC
+- [design/vision-vs-reality.md](design/vision-vs-reality.md) — the July
+  2026 retrospective that reads those two back against what got built
+
+## 5. For humans
+
+- `README.md` (repo root) — the project's front door
+- `LLM-Monster-Hunter-For-Friends/` — a plain-language explanation for
+  friends, no technical background assumed
+
+Update when the pitch, the screenshots, or the setup steps change.
+
+## 6. For curiosity
+
+- `sdlc-project-management/` — an educational reconstruction of what this
+  project's paperwork would look like as a formal phased SDLC with a team,
+  a sponsor, and a budget. Self-labelled as illustrative; the reality is a
+  solo hobby project. Owes nothing to the code.
+
+---
+
+## Not documentation
+
+- [assets/](assets/) — images used by the docs and the README (moodboard,
+  diagrams, screenshots)
+
+## Adding a doc
+
+Put it in the category whose maintenance rule you are willing to honour,
+and add it here. A binding doc you will not keep true is worse than no
+doc — it costs a reader the same time to verify as reading the code, so
+they will read the code and stop trusting the folder. If the fact is
+enumerable from the source, prefer a tripwire over a sentence.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,9 @@ equally binding, which makes the whole folder feel perpetually out of
 date — so before reading or updating anything here, find its category.
 
 **Only the first category owns you.** Eleven of the 44 files in `docs/`
-have to be true (plus root `CLAUDE.md`). The rest are records, plans, or
-daydreams, and several would be damaged by being brought "up to date".
+have to be true, plus root `CLAUDE.md` and five docs that live in the
+code. The rest are records, plans, or daydreams, and several would be
+damaged by being brought "up to date".
 
 ---
 
@@ -22,6 +23,13 @@ bug: fix it in the same commit.
 | [tuning.md](tuning.md) | Every gameplay knob, where it lives, its default |
 | [api/](api/) (9 files) | The HTTP surface, as a reference for working the frontend without reading backend code |
 | `CLAUDE.md` (repo root) | Conventions, commands, the hard rules |
+
+Four more binding docs live **in the code**, not here — the rules for
+working in a subtree, kept next to the subtree because nothing can test
+them: `backend/game/CLAUDE.md`, `backend/tests/CLAUDE.md`,
+`frontend/src/shared/CLAUDE.md`, `frontend/src/components/CLAUDE.md`.
+`frontend/src/shared/ui/ui.md` is a fifth — the prop reference for every
+UI primitive. Root `CLAUDE.md` indexes them all.
 
 **Parts of this category are enforced, not trusted.**
 `backend/tests/test_event_parity.py` asserts that the event catalog in

--- a/docs/api/events-and-sse.md
+++ b/docs/api/events-and-sse.md
@@ -94,6 +94,11 @@ and the item-consumption flows:
   mid-run was taken back — the run's spoils were forfeited on defeat/abandon)
 
 ### Game-state domain events
+- `game.party_updated` — `{ monster_id, monster_name, joined_party, party_ids }`:
+  the backend reshaped the roster on its own (a new follower, possibly
+  auto-seated into an open party slot). `party_ids` is the lineup after
+  the change, player first. PartyContext refetches the following list and
+  the active party on it.
 - `game.world_erased` — `{ deleted_rows }` (per-table counts): New Game
   wiped the world. Emitted AFTER the wipe transaction commits, so
   listeners that refetch on it read the empty world (PartyContext empties

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,10 @@ The pieces:
 - **Step names are a contract.** The frontend's event hooks key off each
   workflow's `on_update` step strings (`useDungeonEvents.js`,
   `useBattleEvents.js`). Renaming a step is a breaking change; treat step
-  names and payload keys like an API.
+  names and payload keys like an API. Guarded by
+  `tests/test_step_contract.py`: every step the frontend keys off must be
+  one the backend can emit, so a rename fails the suite instead of
+  silently blanking a label.
 
 ## The event system
 
@@ -115,6 +118,11 @@ The pieces:
   `useEventSubscription` / `useStreamedGeneration` and update the moment
   their datum arrives (live card reveal, auto-refreshing Sanctuary).
 - Catalog: [api/events-and-sse.md](api/events-and-sse.md).
+- The four surfaces above are mirrored by hand, so
+  `tests/test_event_parity.py` holds them together: every
+  `send_to_frontend` event needs a handler, every handler file must be
+  spread into `EventProvider`, and the catalog doc must match the
+  registry exactly. The doc is checked like code — it cannot fall behind.
 
 ## The referee philosophy (why there are no numbers in prompts)
 

--- a/docs/plans/codebase-health.md
+++ b/docs/plans/codebase-health.md
@@ -1,6 +1,6 @@
 # Codebase Health — consolidation pass (Hth)
 
-**Status: PLANNED** (not started)
+**Status:** PLANNED (not started)
 **Branch:** `feature/codebase-health` · **Commit prefix:** `Hth-M#`
 **Written:** 2026-07-07, from a full-repo review. Intended to be executable
 by an AI assistant working autonomously — every task names its files, its

--- a/docs/plans/congruence-tripwires.md
+++ b/docs/plans/congruence-tripwires.md
@@ -70,16 +70,42 @@ event registry:
 Verification: `python -m backend.tests.test_event_parity` (11 checks),
 registered in `test_offline_suites.py` so pytest and CI cover it.
 
-### Cng-M2 — The step-name contract — **IN PROGRESS**
+### Cng-M2 — The step-name contract — **IMPLEMENTED**
 
-Workflow `on_update` step strings are the contract `docs/architecture.md`
-calls out as breaking-if-renamed, and they are the least protected thing
-in the repo: bare literals assigned to a local `step` variable in each
-workflow, hand-copied into label maps on the frontend — sometimes in a
-different domain folder than the workflow that emits them.
+`backend/tests/test_step_contract.py` asserts every step string the
+frontend keys off is one the backend can actually emit.
 
-Milestone: give the frontend's references a suite that proves every step
-string it keys off is one the backend can actually emit.
+The contract is **one-directional** by design. A backend step nothing
+displays is ordinary — 76 of the 96 steps are progress pings with no
+frontend reference. A frontend reference to a step the backend cannot
+emit is the bug, because nothing errors: the label just stays blank or
+the branch never runs.
+
+Both emission styles are scanned — the older local `step = "name"`
+variable and the `WorkflowStep` pointer (`step.emit/.mark/.emit_event`)
+used by workflows split across handler modules — as are both reference
+styles: `*_STEP_LABELS` maps and inline `step === 'name'` comparisons in
+the event hooks.
+
+**Deviation from the original plan:** no new registry was introduced. The
+first sketch was to give workflows a declared step manifest, but
+`backend/core/workflow_steps.py` already carries the pointer, and adding
+a second place to name a step would have created one more mirror to keep
+congruent — the exact problem this initiative exists to remove. The
+workflow source stays the source of truth and the suite reads it.
+
+**No drift found** — unlike M1, the step contract was intact. The suite
+was therefore verified by mutation instead: renaming `designing_form` in
+`game/monster/registered_workflows.py` turned it red and named the file
+that would have broken (`useMonsterEvolution.js`). The rename was
+reverted; a tripwire nobody has seen fail is not yet a tripwire.
+
+The suite also guards its own scanners — if a refactor changes how steps
+are written, the step counts fall below their floors and it fails loudly
+rather than passing vacuously forever.
+
+Verification: `python -m backend.tests.test_step_contract` (4 checks),
+registered in `test_offline_suites.py`.
 
 ### Cng-M3 — The docs map — **PLANNED**
 

--- a/docs/plans/congruence-tripwires.md
+++ b/docs/plans/congruence-tripwires.md
@@ -1,6 +1,8 @@
 # Congruence Tripwires (Cng)
 
-**Status:** IN PROGRESS
+**Status:** IMPLEMENTED (August 2026) — all four milestones landed.
+Pending Aaron's live soak: the affinity badge updating mid-run, which
+needs a real dungeon run and could not be driven from a dev session.
 **Branch:** `feature/congruence-tripwires` · **Commit prefix:** `Cng-M#`
 **Written:** 2026-08-01
 
@@ -137,18 +139,37 @@ wrong rule would have been misleading in both directions. Fixed, and
 The map also records which docs are tripwired rather than trusted, so a
 reader can tell at a glance which claims are enforced.
 
-### Cng-M4 — Contract docs for the unverifiable rules — **PLANNED**
+### Cng-M4 — Contract docs for the unverifiable rules — **IMPLEMENTED**
 
-The rules no test can enforce — routes never contain logic, services are
-the trust boundary, the LLM picks words and code owns numbers — get
-proximity as their only available lever: a short contract doc in the
-directory where the temptation to violate them lives.
+Four subtrees now carry a `CLAUDE.md` holding the rules no suite can
+enforce: `backend/game/`, `backend/tests/`, `frontend/src/shared/`,
+`frontend/src/components/`. Root `CLAUDE.md` indexes them and instructs
+that the nearest one be read before editing in its subtree.
 
-Scope to decide at the time: which directories earn one (`backend/game/`,
-`frontend/src/shared/`, `frontend/src/components/`, `backend/tests/` are
-the candidates), and whether they are named `AGENTS.md` or `CLAUDE.md` —
-the latter is auto-loaded by Claude Code when working in that subtree,
-which is most of the point. Test the loading behavior before choosing.
+Each states rules only — the file-role conventions inside a game domain,
+the suite shape and the registration trap in `test_offline_suites.py`,
+what earns a place in `shared/` versus a feature folder, where component
+state and live updates come from. Narrative explanation stays in
+`docs/architecture.md`; repo-wide rules stay in root `CLAUDE.md`; nothing
+is restated in two places.
 
-These files state rules only. Narrative explanation stays in
-`docs/architecture.md`; enumerable facts stay tripwired. No duplication.
+**Naming: `CLAUDE.md`, and the deciding test was inconclusive.** Probe
+files were planted at `backend/game/AGENTS.md` and
+`backend/game/CLAUDE.md` and files in that subtree were read; neither
+marker appeared in context. That does not prove nested auto-load is
+unsupported — context files are plausibly discovered at session start, so
+a file created mid-session would not be picked up either way, and the
+test cannot tell those cases apart from inside one session.
+
+The choice was therefore made on other grounds: this is a solo project
+worked through Claude Code, `CLAUDE.md` is the name that toolchain is
+built around, and cross-tool portability is speculative value. Because
+auto-load could not be confirmed, **the root file names the four docs
+explicitly** — the chain is read by instruction, not by hoping the
+harness injects it. That holds whichever way auto-load actually behaves,
+and the decision is a rename away from being reversed.
+
+**Correction to M3:** the docs map listed only `docs/` and root
+`CLAUDE.md` as binding. Five binding docs live in the code — these four
+plus `frontend/src/shared/ui/ui.md`, the prop reference for the UI
+primitives. The map now says so.

--- a/docs/plans/congruence-tripwires.md
+++ b/docs/plans/congruence-tripwires.md
@@ -1,6 +1,6 @@
 # Congruence Tripwires (Cng)
 
-**Status: IN PROGRESS**
+**Status:** IN PROGRESS
 **Branch:** `feature/congruence-tripwires` · **Commit prefix:** `Cng-M#`
 **Written:** 2026-08-01
 
@@ -107,17 +107,35 @@ rather than passing vacuously forever.
 Verification: `python -m backend.tests.test_step_contract` (4 checks),
 registered in `test_offline_suites.py`.
 
-### Cng-M3 — The docs map — **PLANNED**
+### Cng-M3 — The docs map — **IMPLEMENTED**
 
-`docs/` holds six kinds of document with different audiences and
-different maintenance rules — binding, historical, aspirational, work
-orders, for humans, for curiosity — with no signal about which is which.
-The cost is not size, it is that everything reads as equally binding, so
-nothing feels reliably current.
+`docs/README.md` sorts every documentation surface into its six
+categories and states each one's maintenance rule. Every file was
+classified from its own header rather than from memory.
 
-Milestone: a `docs/README.md` that names each category, lists what is in
-it, and states its maintenance rule (must be true / must not be updated /
-congruent with nothing).
+The headline it exists to deliver: **eleven of the 44 files in `docs/`
+are binding** (`architecture.md`, `tuning.md`, the nine `api/` files),
+plus root `CLAUDE.md`. The rest are records, plans, or daydreams, and
+several — the Feb 2025 design deliverables, the retrospective — would be
+damaged by being brought "up to date". The folder felt like a standing
+debt because nothing said which was which.
+
+Plan-doc status lines were also normalised to one markup, `**Status:**`
+followed by the value. Three files wrapped the value inside the bold
+(`**Status: PLANNED**`) and one had no bold at all, so any reader — or
+future tripwire — scanning statuses would have missed them. All 13 now
+match, which is what lets the map state the counts as fact.
+
+**Correction found while classifying:** `CLAUDE.md` described
+`docs/design/` as "the historical design phase". It is mixed — the Feb
+2025 deliverables and `vision-vs-reality.md` are frozen history, while
+`wish-engine.md`, `imagination-engine/`, and `setting-engine/` are
+unbuilt proposals that are congruent with nothing. Reading them under the
+wrong rule would have been misleading in both directions. Fixed, and
+`CLAUDE.md` now points at the map first.
+
+The map also records which docs are tripwired rather than trusted, so a
+reader can tell at a glance which claims are enforced.
 
 ### Cng-M4 — Contract docs for the unverifiable rules — **PLANNED**
 

--- a/docs/plans/congruence-tripwires.md
+++ b/docs/plans/congruence-tripwires.md
@@ -1,0 +1,110 @@
+# Congruence Tripwires (Cng)
+
+**Status: IN PROGRESS**
+**Branch:** `feature/congruence-tripwires` · **Commit prefix:** `Cng-M#`
+**Written:** 2026-08-01
+
+---
+
+## Why this exists
+
+Several contracts in this repo are mirrored **by hand** across files that
+no tool compares: a string in Python has to equal a string in JavaScript,
+and nothing notices when they stop matching. `docs/architecture.md`
+already states the most important of these contracts in prose, and the
+drift happened anyway — because a document describes a contract, it
+cannot detect a violation.
+
+The first pass found exactly that, twice over: `monster.affinity_changed`
+shipped with no frontend handler at all, and `game.party_updated` was
+missing from the event catalog doc. Neither was noticeable by reading.
+
+**The goal of this initiative is not more documentation. It is to make
+the mirrors fail loudly.** Each milestone takes one hand-maintained
+mirror and gives it a suite that goes red the moment the two sides
+disagree.
+
+## Locked decisions
+
+1. **The backend is the source of truth** in every mirror. Suites assert
+   that other surfaces agree with it, never the reverse.
+2. **Tripwire suites are offline and cheap** — no DB, no LLM, no network.
+   They read source files and compare sets. A suite that needs a running
+   game is out of scope here.
+3. **Verifiable and unverifiable contracts get different treatments.**
+   Facts a machine can enumerate (event names, route lists, step names)
+   get tripwires. Judgment rules ("routes never contain logic") cannot be
+   tested and get proximity instead — a contract doc next to the code.
+   Milestones M1–M2 are the first kind; M4 is the second.
+4. **No renaming.** These suites observe existing contracts. Renaming an
+   event, a step string, or a workflow is explicitly out of scope — the
+   step-name contract in `docs/architecture.md` stays intact.
+5. **Reference docs that can be checked, get checked.** `docs/api/` is
+   only worth reading if it cannot quietly fall behind, so the parts of it
+   that are enumerable are asserted against the code.
+
+## Milestones
+
+### Cng-M1 — Event parity — **IMPLEMENTED**
+
+`backend/tests/test_event_parity.py` asserts four surfaces agree with the
+event registry:
+
+- every `send_to_frontend` event has a frontend handler, and every
+  handler maps to a real event
+- no handler listens for an internal-only event
+- every `*EventHandlers.js` file is actually spread into `EventProvider.js`
+  (an unwired handler file is inert no matter how correct it looks)
+- `docs/api/events-and-sse.md` lists every SSE event and invents none
+
+**Drift found and fixed on the first run:**
+
+- `monster.affinity_changed` was declared, emitted from
+  `game/monster/affinity.py`, and had no frontend handler — a monster's
+  trust tier climbed mid-run and the party panel kept showing the old
+  badge until an unrelated refetch. Handler added to
+  `monsterEventHandlers.js`; `PartyProvider` patches the field in place.
+- `game.party_updated` was fully wired in code but undocumented in the
+  event catalog. Added.
+
+Verification: `python -m backend.tests.test_event_parity` (11 checks),
+registered in `test_offline_suites.py` so pytest and CI cover it.
+
+### Cng-M2 — The step-name contract — **IN PROGRESS**
+
+Workflow `on_update` step strings are the contract `docs/architecture.md`
+calls out as breaking-if-renamed, and they are the least protected thing
+in the repo: bare literals assigned to a local `step` variable in each
+workflow, hand-copied into label maps on the frontend — sometimes in a
+different domain folder than the workflow that emits them.
+
+Milestone: give the frontend's references a suite that proves every step
+string it keys off is one the backend can actually emit.
+
+### Cng-M3 — The docs map — **PLANNED**
+
+`docs/` holds six kinds of document with different audiences and
+different maintenance rules — binding, historical, aspirational, work
+orders, for humans, for curiosity — with no signal about which is which.
+The cost is not size, it is that everything reads as equally binding, so
+nothing feels reliably current.
+
+Milestone: a `docs/README.md` that names each category, lists what is in
+it, and states its maintenance rule (must be true / must not be updated /
+congruent with nothing).
+
+### Cng-M4 — Contract docs for the unverifiable rules — **PLANNED**
+
+The rules no test can enforce — routes never contain logic, services are
+the trust boundary, the LLM picks words and code owns numbers — get
+proximity as their only available lever: a short contract doc in the
+directory where the temptation to violate them lives.
+
+Scope to decide at the time: which directories earn one (`backend/game/`,
+`frontend/src/shared/`, `frontend/src/components/`, `backend/tests/` are
+the candidates), and whether they are named `AGENTS.md` or `CLAUDE.md` —
+the latter is auto-loaded by Claude Code when working in that subtree,
+which is most of the point. Test the loading behavior before choosing.
+
+These files state rules only. Narrative explanation stays in
+`docs/architecture.md`; enumerable facts stay tripwired. No duplication.

--- a/docs/plans/monster-depth-cmdts.md
+++ b/docs/plans/monster-depth-cmdts.md
@@ -1,7 +1,7 @@
 # Monster Depth: Expanded Persona + CMDTS — Implementation Plan
 
-Branch: `feature/monster-depth-cmdts`
-Status: IMPLEMENTED (M1–M5, July 2026). Curated trees approved as drafted; both
+**Branch:** `feature/monster-depth-cmdts`
+**Status:** IMPLEMENTED (M1–M5, July 2026). Curated trees approved as drafted; both
 §10 flags resolved as planned (code-derived stats, progressive save). Verify
 offline with `python -m backend.tests.test_monster_templates`; judge generation
 quality with `python -m backend.tests.generate_monster_profiles` (backend running).

--- a/docs/plans/monster-requests.md
+++ b/docs/plans/monster-requests.md
@@ -1,6 +1,6 @@
 # Monster Requests — Implementation Plan
 
-**Status: PLANNED** (not started)
+**Status:** PLANNED (not started)
 **Branch:** `feature/monster-requests` · **Commit prefix:** `Req-M#`
 **Written:** 2026-07-07, from `docs/roadmap.md` initiative #1 + a full read
 of the run-end, memory, affinity, goal, and chat subsystems. Intended to be

--- a/frontend/src/api/events/monsterEventHandlers.js
+++ b/frontend/src/api/events/monsterEventHandlers.js
@@ -56,6 +56,18 @@ export const monsterEventHandlers = {
     broadcastEvent('monsterMemoryAdded', transformedData);
   },
 
+  // The monster's trust in the party climbed a tier. Affinity gates real
+  // behavior (a wary monster acts on its own in battle), so the roster has
+  // to learn about it the moment it changes rather than at the next refetch
+  'monster.affinity_changed': (eventData) => {
+    const transformedData = {
+      monsterId: eventData.monster_id || null,
+      affinity: eventData.affinity || null,
+      reason: eventData.reason || null,
+    };
+    broadcastEvent('monsterAffinityChanged', transformedData);
+  },
+
   // The evolution ceremony's transform moment - identity, stats, and
   // rarity just flipped in place; the record carries the old form
   'monster.evolved': (eventData) => {

--- a/frontend/src/app/contexts/PartyContext/PartyProvider.js
+++ b/frontend/src/app/contexts/PartyContext/PartyProvider.js
@@ -102,6 +102,13 @@ function PartyProvider({ children }) {
     );
   });
 
+  // Trust climbed a tier mid-run - patch just that field so the party
+  // panel's affinity badge stops showing the old tier
+  useEventSubscription('monsterAffinityChanged', ({ monsterId, affinity }) => {
+    if (!monsterId || !affinity) return;
+    patchRosterLists((monster) => (monster.id === monsterId ? { ...monster, affinity } : monster));
+  });
+
   useEventSubscription('monsterArtReady', ({ monsterId, imagePath }) => {
     if (!monsterId || !imagePath) return;
     patchRosterLists((monster) =>

--- a/frontend/src/components/CLAUDE.md
+++ b/frontend/src/components/CLAUDE.md
@@ -1,0 +1,52 @@
+# frontend/src/components/ — feature components
+
+Rules for working in this directory. Repo-wide rules are in the root
+`CLAUDE.md`.
+
+## Folder shape
+
+One folder per feature (`battle/`, `dungeon/`, `chat/`, `cards/`,
+`evolution/`, `player/`, `inventory/`, `settings/`, `streaming/`,
+`developer/`, `debug/`…). Each has an `index.js` barrel — that barrel is
+the feature's public surface, and other features import through it rather
+than reaching into files.
+
+Larger features split further into `components/`, `screens/`, and
+`hooks/`. Small ones stay flat. Follow the neighbours.
+
+## Where state and data come from
+
+- **Shared state** lives in `app/contexts/` (Navigation, Party, Dungeon,
+  Battle, Event). Read it through the context, do not duplicate it here.
+- **Server data** goes through `api/` services. Components do not build
+  URLs or call `fetch` directly.
+- **Live updates** arrive through `useEventSubscription` and
+  `useStreamedGeneration`. Never open an `EventSource` in a component —
+  there is one SSE connection, owned by `EventProvider`.
+
+## String literals here are backend contracts
+
+Two kinds of string in this directory are shared with Python and are
+checked by suites:
+
+- **Workflow step names** in `*_STEP_LABELS` maps and in
+  `step === '...'` comparisons. Referencing a step the backend cannot
+  emit fails `backend/tests/test_step_contract.py` — and silently shows
+  nothing if it ever escapes the suite.
+- **Event names** in `api/events/*EventHandlers.js`, checked against the
+  backend registry by `backend/tests/test_event_parity.py`. A new handler
+  file must also be spread into `EventProvider.js` or its events are
+  never delivered.
+
+## UI primitives
+
+Import from `shared/ui` (the `ui/index.js` barrel, or a primitive's own
+`index.js`). If something presentational is wanted by a second feature,
+move it to `shared/ui/` rather than importing across feature folders.
+
+## Verification
+
+```bash
+npx prettier --check src     # from frontend/
+npm test                     # jest
+```

--- a/frontend/src/shared/CLAUDE.md
+++ b/frontend/src/shared/CLAUDE.md
@@ -1,0 +1,45 @@
+# frontend/src/shared/ — the cross-feature layer
+
+Rules for working in this directory. Repo-wide rules are in the root
+`CLAUDE.md`.
+
+## What belongs here
+
+**Only things used by more than one feature.** If exactly one feature
+needs it, it belongs in `components/<feature>/`. Moving something here
+"because it might be reused" is how a shared layer turns into a second
+components folder.
+
+- `ui/` — the component library (presentational primitives only)
+- `styles/` — theme, typography, colour, globals
+- `hooks/` — cross-feature React hooks
+- `constants/`, `utils/` — cross-feature values and helpers
+
+## ui/ conventions
+
+- One folder per primitive (`Button/`, `Card/`, `Form/`…), containing the
+  component files, its `.css`, and an `index.js` barrel.
+- Everything is re-exported from `ui/index.js`, which is the front door
+  most features import from.
+- **Primitives stay presentational.** No game vocabulary, no API calls,
+  no context reads. A primitive that knows what a monster is belongs in
+  `components/`.
+- [`ui/ui.md`](ui/ui.md) is the prop reference for every primitive.
+  Changing a component's props or its exported constants means updating
+  it in the same change — nothing checks this, so it is on you.
+
+## styles/
+
+Components consume theme tokens rather than hardcoding colours or sizes.
+When a value needs to exist in more than one component, it belongs in
+`styles/`, not repeated in two `.css` files.
+
+## Verification
+
+```bash
+npx prettier --check src     # from frontend/
+npm test                     # jest
+```
+
+ESLint enforces the repo's `max-lines` ceiling here as well as in the
+rest of `src/`.

--- a/setup/checks/database_checks.py
+++ b/setup/checks/database_checks.py
@@ -83,9 +83,7 @@ def check_mysql_server_connection():
     if not config:
         return False, "Invalid or missing database configuration"
 
-    connection, error = connect(
-        config['host'], config['port'], config['user'], config['password']
-    )
+    connection, error = connect(config['host'], config['port'], config['user'], config['password'])
     if connection is None:
         return False, f"MySQL connection failed: {error}"
 
@@ -104,7 +102,10 @@ def check_database_exists():
         return False, "Invalid or missing database configuration"
 
     connection, error = connect(
-        config['host'], config['port'], config['user'], config['password'],
+        config['host'],
+        config['port'],
+        config['user'],
+        config['password'],
         database=config['name'],
     )
     if connection is None:

--- a/tools/check_all.py
+++ b/tools/check_all.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Run every check CI runs, in one command, before pushing.
+
+    ./venv/Scripts/python.exe tools/check_all.py            # all six
+    ./venv/Scripts/python.exe tools/check_all.py backend    # skip npm
+    ./venv/Scripts/python.exe tools/check_all.py frontend   # only npm
+
+`.github/workflows/ci.yml` runs exactly these six checks, so a green run
+here means a green PR. This script is a local convenience only - CI does
+not call it, so the workflow stays the source of truth for what must pass.
+If you add a step to the workflow, add it here too.
+
+Every check runs even after one fails, so a single pass shows everything
+that needs fixing. Two of them have a fix mode worth knowing:
+
+    python -m ruff format backend setup tools    # fixes 'format'
+    npx prettier --write src                     # fixes 'prettier' (in frontend/)
+
+MySQL must be running for the offline suites.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Emoji output survives Windows consoles that default to cp1252
+if hasattr(sys.stdout, 'reconfigure'):
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND_DIR = REPO_ROOT / 'frontend'
+
+# sys.executable is whichever interpreter is running this script, so the
+# checks use the same venv the caller used - no hardcoded venv path
+PYTHON = sys.executable
+
+
+def backend_checks():
+    return [
+        ('lint', [PYTHON, '-m', 'ruff', 'check', 'backend', 'setup', 'tools'], REPO_ROOT),
+        (
+            'format',
+            [PYTHON, '-m', 'ruff', 'format', '--check', 'backend', 'setup', 'tools'],
+            REPO_ROOT,
+        ),
+        ('file sizes', [PYTHON, 'tools/check_file_sizes.py'], REPO_ROOT),
+        ('offline suites', [PYTHON, '-m', 'pytest'], REPO_ROOT),
+    ]
+
+
+def frontend_checks():
+    # npm ships as npm.cmd / npx.cmd on Windows; which() resolves either
+    npx = shutil.which('npx')
+    npm = shutil.which('npm')
+    if not npx or not npm:
+        return None
+    return [
+        ('prettier', [npx, 'prettier', '--check', 'src'], FRONTEND_DIR),
+        (
+            'jest',
+            [npm, 'test', '--', '--watchAll=false', '--passWithNoTests'],
+            FRONTEND_DIR,
+        ),
+    ]
+
+
+def run(name: str, command: list, cwd: Path) -> bool:
+    """Run one check, print its verdict, return whether it passed"""
+    started = time.monotonic()
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding='utf-8',
+        errors='replace',
+        # CI sets both; pytest needs the encoding, jest needs CI=true to
+        # run once instead of entering watch mode
+        env={**os.environ, 'PYTHONIOENCODING': 'utf-8', 'CI': 'true'},
+    )
+    elapsed = time.monotonic() - started
+
+    if result.returncode == 0:
+        print(f"  ✅ {name} ({elapsed:.1f}s)")
+        return True
+
+    print(f"  ❌ {name} ({elapsed:.1f}s)")
+    output = (result.stdout or '') + (result.stderr or '')
+    for line in output.strip().splitlines():
+        print(f"       {line}")
+    return False
+
+
+def main():
+    requested = sys.argv[1] if len(sys.argv) > 1 else 'all'
+    if requested not in ('all', 'backend', 'frontend'):
+        print(f"Unknown argument {requested!r} - expected 'backend', 'frontend', or nothing")
+        return 2
+
+    checks = []
+    if requested in ('all', 'backend'):
+        checks += backend_checks()
+    if requested in ('all', 'frontend'):
+        frontend = frontend_checks()
+        if frontend is None:
+            print('❌ npm/npx not found on PATH - cannot run the frontend checks')
+            return 2
+        checks += frontend
+
+    print(f"🔍 RUNNING {len(checks)} CI CHECKS")
+    print('=' * 50)
+
+    failed = [name for name, command, cwd in checks if not run(name, command, cwd)]
+
+    print('=' * 50)
+    if failed:
+        print(f"❌ {len(checks) - len(failed)} passed, {len(failed)} failed: {', '.join(failed)}")
+        print('   Fix these before pushing - CI runs the same checks.')
+        return 1
+
+    print(f"🎉 all {len(checks)} checks passed - safe to push")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Several contracts in this repo are mirrored **by hand** across files that no tool compares — a string in Python has to equal a string in JavaScript, and nothing notices when they stop matching. `docs/architecture.md` already stated the most important of these in prose, and the drift happened anyway, because **a document describes a contract but cannot detect a violation.**

This initiative takes each hand-maintained mirror and gives it a suite that goes red when the two sides disagree. Four milestones, `Cng-M1`..`Cng-M4`. Plan doc: `docs/plans/congruence-tripwires.md`.

## Cng-M1 — Event parity

`backend/tests/test_event_parity.py` asserts four surfaces agree with the backend event registry: every `send_to_frontend` event has a frontend handler, every handler maps to a real event, every `*EventHandlers.js` file is actually spread into `EventProvider.js`, and `docs/api/events-and-sse.md` matches the registry exactly.

**Two drifts found on the first run, both fixed here:**

- `monster.affinity_changed` was declared, emitted from `game/monster/affinity.py`, and had **no frontend handler at all**. A monster's trust climbing a tier mid-run left the party panel's affinity badge stale until an unrelated refetch. Handler added; `PartyProvider` patches the field in place.
- `game.party_updated` was fully wired in code but missing from the event catalog doc — invisible when reading, because it is an absence.

## Cng-M2 — Step-name contract

`backend/tests/test_step_contract.py` asserts every workflow step string the frontend keys off is one the backend can emit. One-directional by design: 76 of the 96 steps are progress pings nothing displays, but a dangling frontend reference never errors — the label just stays blank forever.

No drift found, so it was verified by **mutation**: renaming `designing_form` turned it red and named `useMonsterEvolution.js` as the file that would have broken. Reverted.

*Deviation from plan:* no new step registry. `core/workflow_steps.py` already carries the pointer, and a second place to name a step would be one more mirror to keep congruent — the exact problem this initiative removes.

## Cng-M3 — The docs map

`docs/README.md` sorts every documentation surface into six categories with opposite maintenance rules: binding (must be true), work orders (keep the diary), aspirational (congruent with nothing), historical (must **not** be updated), for humans, for curiosity.

The headline: **11 of the 44 files in `docs/` are binding.** The rest are records, plans, or daydreams — several would be damaged by being brought "up to date". Every file was classified from its own header.

Corrections found while classifying: `CLAUDE.md` described `docs/design/` as "the historical design phase" when it is mixed (frozen deliverables *and* unbuilt proposals), and plan-doc status lines used three different markups, now normalised so all 13 scan uniformly.

## Cng-M4 — Directory contract docs

Four subtrees now carry a `CLAUDE.md` with the rules no suite can enforce — `backend/game/`, `backend/tests/`, `frontend/src/shared/`, `frontend/src/components/`. 209 lines total, rules only, nothing restated from `architecture.md` or root `CLAUDE.md`.

Captures things that were nowhere: the `manager`/`generator`/`registered_workflows` file roles, that **a suite missing from `test_offline_suites.py`'s `SUITES` passes silently by never running**, that `shared/ui` primitives must stay presentational, that components must never open their own `EventSource`.

*Naming note:* the auto-load test was **inconclusive** — probes at `backend/game/AGENTS.md` and `backend/game/CLAUDE.md` neither reached context, but a file created mid-session would be missed either way. Chose `CLAUDE.md` on other grounds and made root `CLAUDE.md` name all four explicitly, so the chain is read by instruction rather than by hoping the harness injects it.

## Verification

- Offline suites: **20 passed** (18 before this branch), ~4s
- `ruff check` clean · `prettier --check src` clean · file-size ceiling clean
- Frontend boots and `PartyProvider` mounts cleanly

**Not verified — one live soak item:** the affinity badge updating mid-run needs a real dungeon run with a monster's trust climbing, which can't be driven from a dev session. Logged in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
